### PR TITLE
feat: add default rpc's and remove rpc_key env

### DIFF
--- a/pragma/core/client.py
+++ b/pragma/core/client.py
@@ -39,7 +39,7 @@ class PragmaClient(NonceMixin, OracleMixin, PublisherRegistryMixin, TransactionM
     ):
         """
         Client for interacting with Pragma on Starknet.
-        :param network: Target network for the client. Can be a string with URL, one of ``"mainnet"``, ``"testnet"``, ``"local"`` or ``"integration""``
+        :param network: Target network for the client. Can be a URL string, or one of ``"pragma_testnet"``, ``"sharingan"`` or ``"devnet"``
         :param account_private_key: Optional private key for requests.  Not necessary if not making network updates
         :param account_contract_address: Optional account contract address.  Not necessary if not making network updates
         :param contract_addresses_config: Optional Contract Addresses for Pragma.  Will default to the provided network but must be set if using non standard contracts.

--- a/pragma/core/client.py
+++ b/pragma/core/client.py
@@ -39,7 +39,7 @@ class PragmaClient(NonceMixin, OracleMixin, PublisherRegistryMixin, TransactionM
     ):
         """
         Client for interacting with Pragma on Starknet.
-        :param network: Target network for the client. Can be a URL string, or one of ``"mainnet``, ``"testnet"``, ``"pragma_testnet"``, ``"sharingan"`` or ``"devnet"``
+        :param network: Target network for the client. Can be a URL string, or one of ``"mainnet"``, ``"testnet"``, ``"pragma_testnet"``, ``"sharingan"`` or ``"devnet"``
         :param account_private_key: Optional private key for requests.  Not necessary if not making network updates
         :param account_contract_address: Optional account contract address.  Not necessary if not making network updates
         :param contract_addresses_config: Optional Contract Addresses for Pragma.  Will default to the provided network but must be set if using non standard contracts.

--- a/pragma/core/client.py
+++ b/pragma/core/client.py
@@ -39,7 +39,7 @@ class PragmaClient(NonceMixin, OracleMixin, PublisherRegistryMixin, TransactionM
     ):
         """
         Client for interacting with Pragma on Starknet.
-        :param network: Target network for the client. Can be a URL string, or one of ``"pragma_testnet"``, ``"sharingan"`` or ``"devnet"``
+        :param network: Target network for the client. Can be a URL string, or one of ``"mainnet``, ``"testnet"``, ``"pragma_testnet"``, ``"sharingan"`` or ``"devnet"``
         :param account_private_key: Optional private key for requests.  Not necessary if not making network updates
         :param account_contract_address: Optional account contract address.  Not necessary if not making network updates
         :param contract_addresses_config: Optional Contract Addresses for Pragma.  Will default to the provided network but must be set if using non standard contracts.

--- a/pragma/core/types.py
+++ b/pragma/core/types.py
@@ -8,8 +8,6 @@ from starknet_py.net.full_node_client import FullNodeClient
 
 from pragma.core.utils import str_to_felt
 
-# from starknet_py.net.gateway_client import GatewayClient
-
 
 logging.basicConfig()
 logger = logging.getLogger(__name__)
@@ -44,13 +42,9 @@ STARKSCAN_URLS = {
 }
 
 
-def get_rpc_url(network=TESTNET, rpc_key=None, port=5050):
-    rpc_key = rpc_key if rpc_key is not None else os.getenv("RPC_KEY")
-
-    if network == TESTNET:
-        return f"https://starknet-goerli.infura.io/v3/{rpc_key}"
-    if network == MAINNET:
-        return f"https://starknet-mainnet.infura.io/v3/{rpc_key}"
+def get_rpc_url(network=PRAGMA_TESTNET, port=5050):
+    if network.startswith("http"):
+        return network
     if network == SHARINGAN:
         return "https://sharingan.madara.zone"
     if network == PRAGMA_TESTNET:
@@ -60,7 +54,6 @@ def get_rpc_url(network=TESTNET, rpc_key=None, port=5050):
 
 
 def get_client_from_network(network: str, port=5050):
-    # return GatewayClient(net=f"http://localhost:{port}")
     return FullNodeClient(node_url=get_rpc_url(network, port=port))
 
 

--- a/pragma/core/types.py
+++ b/pragma/core/types.py
@@ -42,9 +42,13 @@ STARKSCAN_URLS = {
 }
 
 
-def get_rpc_url(network=PRAGMA_TESTNET, port=5050):
+def get_rpc_url(network=TESTNET, port=5050):
     if network.startswith("http"):
         return network
+    if network == TESTNET:
+        return "https://starknet-testnet.public.blastapi.io"
+    if network == MAINNET:
+        return "https://starknet-mainnet.public.blastapi.io"
     if network == SHARINGAN:
         return "https://sharingan.madara.zone"
     if network == PRAGMA_TESTNET:


### PR DESCRIPTION
Addresses #16 

@EvolveArt I could not find an RPC API provider that did not need an API key to operate so I've removed those options for now. Is there a pragma RPC API for mainnet and testnet? Or maybe something that will replace the soon-deprecated feeder gateway?