### PR TITLE
fix: get client id for rpc url

### DIFF
--- a/pragma/core/client.py
+++ b/pragma/core/client.py
@@ -51,7 +51,9 @@ class PragmaClient(NonceMixin, OracleMixin, PublisherRegistryMixin, TransactionM
             Must be one of ``"mainnet"``, ``"testnet"``, ``"pragma_testnet"``, ``"sharingan"`` or ``"devnet"``.
         """
         self.client: FullNodeClient = get_client_from_network(network, port=port)
-        self.network = network if not network.startswith("http") else chain_name
+        if network.startswith("http") and chain_name is None:
+            raise Exception(f"Network provided is a URL: {network} but `chain_name` is not provided.")
+        self.network = network if not(network.startswith("http") and chain_name) else chain_name
         if account_contract_address and account_private_key:
             self._setup_account_client(
                 CHAIN_IDS[self.network],

--- a/pragma/core/client.py
+++ b/pragma/core/client.py
@@ -38,6 +38,7 @@ class PragmaClient(NonceMixin, OracleMixin, PublisherRegistryMixin, TransactionM
         account_contract_address: Optional[int] = None,
         contract_addresses_config: Optional[ContractAddresses] = None,
         port: Optional[int] = None,
+        chain_name: Optional[str] = None,
     ):
         """
         Client for interacting with Pragma on Starknet.
@@ -46,11 +47,11 @@ class PragmaClient(NonceMixin, OracleMixin, PublisherRegistryMixin, TransactionM
         :param account_contract_address: Optional account contract address.  Not necessary if not making network updates
         :param contract_addresses_config: Optional Contract Addresses for Pragma.  Will default to the provided network but must be set if using non standard contracts.
         :param port: Optional port to interact with local node. Will default to 5050.
+        :param chain_name: A str-representation of the chain if a URL string is given for `network`.
+            Must be one of ``"mainnet"``, ``"testnet"``, ``"pragma_testnet"``, ``"sharingan"`` or ``"devnet"``.
         """
         self.client: FullNodeClient = get_client_from_network(network, port=port)
-        chain_id = self.client.get_chain_id_sync()
-        self.network = hex_to_chain_id(chain_id)
-
+        self.network = network if not network.startswith("http") else chain_name
         if account_contract_address and account_private_key:
             self._setup_account_client(
                 CHAIN_IDS[self.network],

--- a/pragma/core/client.py
+++ b/pragma/core/client.py
@@ -19,7 +19,6 @@ from pragma.core.types import (
     ContractAddresses,
     get_client_from_network,
 )
-from pragma.core.utils import hex_to_chain_id
 
 logging.basicConfig()
 logger = logging.getLogger(__name__)

--- a/pragma/core/utils.py
+++ b/pragma/core/utils.py
@@ -1,6 +1,5 @@
 import logging
 
-from starknet_py.net.full_node_client import FullNodeClient
 
 logger = logging.getLogger(__name__)
 
@@ -36,3 +35,12 @@ def pair_id_for_asset(asset):
         asset["key"] if "key" in asset else currency_pair_to_pair_id(*asset["pair"])
     )
     return pair_id
+
+
+def hex_to_chain_id(hex):
+    hex = hex.removeprefix("0x")
+    chain_id = bytes.fromhex(hex)
+    return {
+        "SN_GOERLI": "testnet",
+        "SN_MAIN": "mainnet"
+    }.get(chain_id, "testnet")

--- a/pragma/core/utils.py
+++ b/pragma/core/utils.py
@@ -35,12 +35,3 @@ def pair_id_for_asset(asset):
         asset["key"] if "key" in asset else currency_pair_to_pair_id(*asset["pair"])
     )
     return pair_id
-
-
-def hex_to_chain_id(hex):
-    hex = hex.removeprefix("0x")
-    chain_id = bytes.fromhex(hex)
-    return {
-        "SN_GOERLI": "testnet",
-        "SN_MAIN": "mainnet"
-    }.get(chain_id, "testnet")

--- a/pragma/tests/client_test.py
+++ b/pragma/tests/client_test.py
@@ -324,8 +324,19 @@ async def test_client_oracle_mixin_future(pragma_client: PragmaClient, contracts
 
 
 def test_client_with_http_network():
-    client = PragmaClient(
+    client_with_chain_name = PragmaClient(
         network="http://test.rpc/rpc",
         chain_name="testnet"
     )
-    assert client.network == "testnet"
+    assert client_with_chain_name.network == "testnet"
+
+    client_with_chain_name_only = PragmaClient(chain_name="devnet")
+    # default value of network is testnet
+    assert client_with_chain_name_only.network == "testnet"
+
+    with pytest.raises(Exception) as e:
+        _ = PragmaClient(
+            network="http://test.rpc/rpc"
+        )
+        assert "`chain_name` is not provided" in str(e)
+

--- a/pragma/tests/client_test.py
+++ b/pragma/tests/client_test.py
@@ -4,8 +4,7 @@ from urllib.parse import urlparse
 
 import pytest
 import pytest_asyncio
-import requests_mock
-from aioresponses import aioresponses
+
 from starknet_py.contract import Contract, DeclareResult, DeployResult
 from starknet_py.net.account.base_account import BaseAccount
 from starknet_py.net.client_errors import ClientError
@@ -325,12 +324,8 @@ async def test_client_oracle_mixin_future(pragma_client: PragmaClient, contracts
 
 
 def test_client_with_http_network():
-    with aioresponses() as mock:
-        mock.post(
-            url="http://test.rpc/rpc",
-            payload={"id": 1, "jsonrpc": "2.0", "result": "0x534e5f474f45524c49"},
-        )
-        client = PragmaClient(
-            network="http://test.rpc/rpc",
-        )
-        assert client.network == "testnet"
+    client = PragmaClient(
+        network="http://test.rpc/rpc",
+        chain_name="testnet"
+    )
+    assert client.network == "testnet"


### PR DESCRIPTION
addresses #33 

This PR fetches the chain ID from the Starknet RPC API when an RPC URL is given. As a result, it only returns `"testnet"` and `"mainnet"` chain IDs for now.

Another approach is to require users to pass in a data type that includes url and chain name.