### PR TITLE
✨ TheGraph UniV3 Spot

### DIFF
--- a/pragma/core/client.py
+++ b/pragma/core/client.py
@@ -9,18 +9,18 @@ from pragma.core.abis import ABIS
 from pragma.core.contract import Contract
 from pragma.core.mixins import (
     NonceMixin,
+    OffchainMixin,
     OracleMixin,
     PublisherRegistryMixin,
     TransactionMixin,
-    OffchainMixin
 )
 from pragma.core.types import (
     CHAIN_IDS,
     CONTRACT_ADDRESSES,
+    PRAGMA_API_URL,
     ClientException,
     ContractAddresses,
     get_client_from_network,
-    PRAGMA_API_URL
 )
 
 logging.basicConfig()
@@ -28,7 +28,9 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 
-class PragmaClient(NonceMixin, OracleMixin, PublisherRegistryMixin, TransactionMixin, OffchainMixin):
+class PragmaClient(
+    NonceMixin, OracleMixin, PublisherRegistryMixin, TransactionMixin, OffchainMixin
+):
     is_user_client: bool = False
     account_contract_address: Optional[int] = None
     account: Account = None

--- a/pragma/core/mixins/__init__.py
+++ b/pragma/core/mixins/__init__.py
@@ -1,5 +1,5 @@
 from pragma.core.mixins.nonce import NonceMixin
+from pragma.core.mixins.offchain import OffchainMixin
 from pragma.core.mixins.oracle import OracleMixin
 from pragma.core.mixins.publisher_registry import PublisherRegistryMixin
 from pragma.core.mixins.transactions import TransactionMixin
-from pragma.core.mixins.offchain import OffchainMixin

--- a/pragma/core/mixins/offchain.py
+++ b/pragma/core/mixins/offchain.py
@@ -1,11 +1,11 @@
 import collections
-import logging
-from typing import List, Dict
-import time
 import io
+import logging
 import ssl
-import aiohttp
+import time
+from typing import Dict, List
 
+import aiohttp
 from starknet_py.net.account.account import Account
 from starknet_py.net.client import Client
 from starknet_py.utils.typed_data import TypedData
@@ -34,6 +34,8 @@ GetDataResponse = collections.namedtuple(
 price': 1000, 
 'volume': 0}
 """
+
+
 def build_publish_message(entries: List[SpotEntry]) -> TypedData:
     message = {
         "domain": {"name": "Pragma", "version": "1"},
@@ -52,15 +54,15 @@ def build_publish_message(entries: List[SpotEntry]) -> TypedData:
                 {"name": "entries", "type": "Entry*"},
             ],
             "Entry": [
-                { "name": "base", "type": "Base" },
-                { "name": "pair_id", "type": "felt" },
-                { "name": "price", "type": "felt" },
-                { "name": "volume", "type": "felt" },
+                {"name": "base", "type": "Base"},
+                {"name": "pair_id", "type": "felt"},
+                {"name": "price", "type": "felt"},
+                {"name": "volume", "type": "felt"},
             ],
             "Base": [
-                { "name": "publisher", "type": "felt" },
-                { "name": "source", "type": "felt" },
-                { "name": "timestamp", "type": "felt" },
+                {"name": "publisher", "type": "felt"},
+                {"name": "source", "type": "felt"},
+                {"name": "timestamp", "type": "felt"},
             ],
         },
     }
@@ -92,7 +94,9 @@ class OffchainMixin:
         """
 
         ssl_context = ssl.create_default_context(ssl.Purpose.SERVER_AUTH)
-        ssl_context.load_cert_chain(certfile=io.StringIO(client_cert), keyfile=io.StringIO(client_key))
+        ssl_context.load_cert_chain(
+            certfile=io.StringIO(client_cert), keyfile=io.StringIO(client_key)
+        )
         self.ssl_context = ssl_context
 
     async def publish_data(
@@ -124,14 +128,16 @@ class OffchainMixin:
             "entries": SpotEntry.offchain_serialize_entries(entries),
         }
 
-        url = self.api_url + '/v1/data/publish'
+        url = self.api_url + "/v1/data/publish"
 
         logging.info(f"POST {url}")
         logging.info(f"Headers: {headers}")
         logging.info(f"Body: {body}")
 
         # Call Pragma API
-        async with aiohttp.ClientSession(connector=aiohttp.TCPConnector(ssl_context=self.ssl_context)) as session:
+        async with aiohttp.ClientSession(
+            connector=aiohttp.TCPConnector(ssl_context=self.ssl_context)
+        ) as session:
             async with session.post(url, headers=headers, json=body) as response:
                 status_code: int = response.status
                 response: Dict = await response.json()
@@ -171,7 +177,9 @@ class OffchainMixin:
 
         logging.info(f"GET {url}")
 
-        async with aiohttp.ClientSession(connector=aiohttp.TCPConnector(ssl_context=self.ssl_context)) as session:
+        async with aiohttp.ClientSession(
+            connector=aiohttp.TCPConnector(ssl_context=self.ssl_context)
+        ) as session:
             async with session.get(url, headers=headers) as response:
                 status_code: int = response.status
                 response: Dict = await response.json()

--- a/pragma/publisher/client.py
+++ b/pragma/publisher/client.py
@@ -57,9 +57,13 @@ class PragmaPublisherClient(PragmaClient):
     def get_fetchers(self):
         return self.fetchers
 
-    async def fetch(self, filter_exceptions=True, return_exceptions=True, timeout_duration=10) -> List[any]:
+    async def fetch(
+        self, filter_exceptions=True, return_exceptions=True, timeout_duration=10
+    ) -> List[any]:
         tasks = []
-        timeout = aiohttp.ClientTimeout(total=timeout_duration)  # 10 seconds per request
+        timeout = aiohttp.ClientTimeout(
+            total=timeout_duration
+        )  # 10 seconds per request
         async with aiohttp.ClientSession(timeout=timeout) as session:
             for fetcher in self.fetchers:
                 data = fetcher.fetch(session)

--- a/pragma/publisher/fetchers/thegraph.py
+++ b/pragma/publisher/fetchers/thegraph.py
@@ -1,16 +1,25 @@
 import asyncio
 import logging
 import time
-from typing import List
+from typing import Dict, List
 
 import requests
 from aiohttp import ClientSession
 
 from pragma.core.assets import PragmaAsset, PragmaSpotAsset
-from pragma.core.entry import GenericEntry
-from pragma.publisher.types import PublisherInterfaceT
+from pragma.core.entry import SpotEntry
+from pragma.core.utils import currency_pair_to_pair_id
+from pragma.publisher.types import PublisherFetchError, PublisherInterfaceT
 
 logger = logging.getLogger(__name__)
+
+ASSET_MAPPING: Dict[str, str] = {
+    "ETH": "0x88e6a0c2ddd26feeb64f039a2c41296fcb3f5640",  # WETH/USDC 500bps pool
+    "BTC": "0x99ac8ca7087fa4a2a1fb6357269965a2014abc35",  # WBTC/USDC 30bps pool
+    "WBTC": "0x99ac8ca7087fa4a2a1fb6357269965a2014abc35",  # WBTC/USDC 30bps pool
+    "DAI": "0x5777d92f208679db4b9778590fa3cab3ac9e2168",  # DAI/USDC 100bps pool
+    "USDC": "0x3416cf6c708da44db2624d63ea0aaef7113527c6",  # USDC/USDT 100bps pool
+}
 
 
 class TheGraphFetcher(PublisherInterfaceT):
@@ -25,85 +34,115 @@ class TheGraphFetcher(PublisherInterfaceT):
 
     async def _fetch_pair(
         self, asset: PragmaSpotAsset, session: ClientSession
-    ) -> GenericEntry:
-        if asset["source"] == "AAVE":
-            url_slug = "aave/protocol-v2"
-            query = (
-                f"query "
-                f"{{reserves(where: {{id: \"{asset['detail']['asset_address']}\"}}) "
-                f"{{name isActive isFrozen {asset['detail']['metric']}}}}}"
+    ) -> SpotEntry:
+        pair = asset["pair"]
+        pool = ASSET_MAPPING.get(pair[0])
+        if pool is None:
+            return PublisherFetchError(
+                f"Unknown price pair, do not know how to query TheGraph for {pair[0]}"
             )
-            input_decimals = 27
-        else:
-            raise ValueError(
-                f"Unknown asset name, do not know how to query The Graph for {asset['name']}"
-            )
+        if pair[1] != "USD":
+            return PublisherFetchError(f"Base asset not supported : {pair[1]}")
+
+        url_slug = "uniswap/uniswap-v3"
+        query = (
+            f"query "
+            f'{{pool(where: {{id: "{pool}"}}) '
+            f"{{volumeUSD token0Price token1Price liquidity sqrtPrice feeTier tick token0 {{symbol}} token1 {{symbol}}}}}}"
+        )
 
         async with session.post(
             self.BASE_URL + url_slug, json={"query": query}
         ) as resp:
+            if resp.status == 404:
+                return PublisherFetchError(
+                    f"No data found for {'/'.join(pair)} from TheGraph"
+                )
             result_json = await resp.json()
-            result = result_json["data"]["reserves"][0]
+            result = result_json["data"]["pool"]
 
-            return self._construct(asset, result, input_decimals=input_decimals)
+            return self._construct(asset, result)
 
-    def _fetch_pair_sync(self, asset: PragmaSpotAsset) -> GenericEntry:
-        if asset["source"] == "AAVE":
-            url_slug = "aave/protocol-v2"
-            query = (
-                f"query {{reserves(where: "
-                f"{{id: \"{asset['detail']['asset_address']}\"}}) "
-                f"{{name isActive isFrozen {asset['detail']['metric']}}}}}"
+    def _fetch_pair_sync(self, asset: PragmaSpotAsset) -> SpotEntry:
+        pair = asset["pair"]
+        pool = ASSET_MAPPING.get(pair[0])
+        if pool is None:
+            return PublisherFetchError(
+                f"Unknown price pair, do not know how to query TheGraph for {pair[0]}"
             )
-            input_decimals = 27
-        else:
-            raise ValueError(
-                f"Unknown asset name, do not know how to query The Graph for {asset['name']}"
-            )
+        if pair[1] != "USD":
+            return PublisherFetchError(f"Base asset not supported : {pair[1]}")
+
+        url_slug = "uniswap/uniswap-v3"
+        query = (
+            f"query "
+            f'{{pool(where: {{id: "{pool}"}}) '
+            f"{{volumeUSD token0Price token1Price liquidity sqrtPrice feeTier tick token0 {{symbol}} token1 {{symbol}}}}}}"
+        )
 
         resp = requests.post(self.BASE_URL + url_slug, json={"query": query})
+        if resp.status_code == 404:
+            return PublisherFetchError(
+                f"No data found for {'/'.join(pair)} from TheGraph"
+            )
         result_json = resp.json()
-        result = result_json["data"]["reserves"][0]
-        return self._construct(asset, result, input_decimals=input_decimals)
+        result = result_json["data"]["pool"]
+        return self._construct(asset, result)
 
-    async def fetch(self, session: ClientSession) -> List[GenericEntry]:
+    async def fetch(self, session: ClientSession) -> List[SpotEntry]:
         entries = []
         for asset in self.assets:
-            if asset["type"] != "ONCHAIN":
-                logger.debug("Skipping The Graph for non-on-chain asset %s", asset)
+            if asset["type"] != "SPOT":
+                logger.debug("Skipping The Graph for non-spot asset %s", asset)
                 continue
             entries.append(asyncio.ensure_future(self._fetch_pair(asset, session)))
         return await asyncio.gather(*entries, return_exceptions=True)
 
-    def fetch_sync(self) -> List[GenericEntry]:
+    def fetch_sync(self) -> List[SpotEntry]:
         entries = []
         for asset in self.assets:
-            if asset["type"] != "ONCHAIN":
-                logger.debug("Skipping The Graph for non-on-chain asset %s", asset)
+            if asset["type"] != "SPOT":
+                logger.debug("Skipping The Graph for non-spot asset %s", asset)
                 continue
             entries.append(self._fetch_pair_sync(asset))
         return entries
 
-    def _construct(self, asset, result, input_decimals=27) -> GenericEntry:
-        key = asset["key"]
+    def format_url(self, quote_asset, base_asset):
+        pool = ASSET_MAPPING[quote_asset]
+        url_slug = "uniswap/uniswap-v3"
+        url = self.BASE_URL + url_slug
+        return url
 
-        if result["name"] != asset["detail"]["asset_name"]:
-            raise ValueError("invalid json")
-        if not result["isActive"] is True:
-            raise ValueError("invalid json")
-        if not result["isFrozen"] is False:
-            raise ValueError("invalid json")
+    def query_body(self, quote_asset):
+        pool = ASSET_MAPPING[quote_asset]
+        query = (
+            f"query "
+            f'{{pool(where: {{id: "{pool}"}}) '
+            f"{{volumeUSD token0Price token1Price liquidity sqrtPrice feeTier tick token0 {{symbol}} token1 {{symbol}}}}}}"
+        )
+        return query
 
-        value = float(result[asset["detail"]["metric"]])
-        value_int = int(value * (10 ** (asset["decimals"] - input_decimals)))
+    def _construct(self, asset, result) -> SpotEntry:
+        pair = asset["pair"]
+
+        if pair[0] in result["token0"]["symbol"]:
+            price = float(result["token1Price"])
+        else:
+            price = float(result["token0Price"])
+
+        price_int = int(price * (10 ** asset["decimals"]))
+        volume = float(result["volumeUSD"])
+
         timestamp = int(time.time())
 
-        logger.info("Fetched data %s for %s from The Graph", value_int, key)
+        pair_id = currency_pair_to_pair_id(*pair)
+        logger.info("Fetched data %s for %s from The Graph", price, pair_id)
 
-        return GenericEntry(
-            key=key,
-            value=value_int,
+        return SpotEntry(
+            pair_id=pair_id,
+            price=price_int,
             timestamp=timestamp,
             source=self.SOURCE,
             publisher=self.publisher,
+            volume=volume,
         )

--- a/pragma/tests/fetcher_configs.py
+++ b/pragma/tests/fetcher_configs.py
@@ -150,6 +150,29 @@ FETCHER_CONFIGS = {
             ),
         ],
     },
+    "TheGraphFetcher": {
+        "mock_file": MOCK_DIR / "responses" / "thegraph.json",
+        "fetcher_class": TheGraphFetcher,
+        "name": "TheGraph",
+        "expected_result": [
+            SpotEntry(
+                "BTC/USD",
+                3459885191309,
+                12345,
+                "THEGRAPH",
+                PUBLISHER_NAME,
+                volume=13263948239.39806410965943312664704,
+            ),
+            SpotEntry(
+                "ETH/USD",
+                180043642780,
+                12345,
+                "THEGRAPH",
+                PUBLISHER_NAME,
+                volume=406618849947.3046337346962943997025,
+            ),
+        ],
+    },
 }
 
 FUTURE_FETCHER_CONFIGS = {

--- a/pragma/tests/fetchers_test.py
+++ b/pragma/tests/fetchers_test.py
@@ -158,6 +158,7 @@ def test_fetcher_sync_success(fetcher_config, mock_data):
             base_asset = asset["pair"][1]
             url = fetcher.format_url(quote_asset, base_asset)
 
+            # TODO (#000): Fix this test
             if fetcher_config["name"] == "TheGraph":
                 query = fetcher.query_body(quote_asset)
                 print(query)

--- a/pragma/tests/mock/responses/thegraph.json
+++ b/pragma/tests/mock/responses/thegraph.json
@@ -1,0 +1,48 @@
+{
+	"BTC": {
+		"data": {
+			"pool": {
+				"tick": "58466",
+				"feeTier": "3000",
+				"sqrtPrice": "1473704561253995103594756241618",
+				"volumeUSD": "13263948239.39806410965943312664704",
+				"liquidity": "12133869505104",
+				"token0": {
+					"symbol": "WBTC",
+					"id": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
+					"decimals": "8"
+				},
+				"token1": {
+					"symbol": "USDC",
+					"id": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+					"decimals": "6"
+				},
+				"token1Price": "34598.85191309621206540718089516201",
+				"token0Price": "0.00002890269314460935050035014629483372"
+			}
+		}
+	},
+	"ETH": {
+		"data": {
+			"pool": {
+				"tick": "201362",
+				"feeTier": "500",
+				"sqrtPrice": "1867199352400732300487913333649122",
+				"volumeUSD": "406618849947.3046337346962943997025",
+				"liquidity": "20753232973335935007",
+				"token0": {
+					"symbol": "USDC",
+					"id": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+					"decimals": "6"
+				},
+				"token1": {
+					"symbol": "WETH",
+					"id": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+					"decimals": "18"
+				},
+				"token1Price": "0.0005554208882661901581013534140168188",
+				"token0Price": "1800.436427808133752849275095979679"
+			}
+		}
+	}
+}

--- a/pragma/tests/offchain_mixin.py
+++ b/pragma/tests/offchain_mixin.py
@@ -3,12 +3,12 @@ from typing import Tuple
 
 import pytest
 import pytest_asyncio
-
 from starknet_py.utils.typed_data import TypedData
+
 from pragma.core.client import PragmaClient
 from pragma.core.entry import SpotEntry
-from pragma.core.utils import str_to_felt
 from pragma.core.mixins.offchain import build_publish_message
+from pragma.core.utils import str_to_felt
 
 PUBLISHER_NAME = "PRAGMA"
 
@@ -20,33 +20,34 @@ SOURCE_2 = "PRAGMA_2"
 SOURCE_3 = "SOURCE_3"
 
 MOCK_DATA = [
-        SpotEntry(
-            pair_id=ETH_PAIR,
-            source=SOURCE_1,
-            publisher=PUBLISHER_NAME,
-            price=1000,
-            timestamp=int(time.time()),
-        ),
-        SpotEntry(
-            pair_id=ETH_PAIR,
-            source=SOURCE_2,
-            publisher=PUBLISHER_NAME,
-            price=1000,
-            timestamp=int(time.time()),
-        ),
-    ]
+    SpotEntry(
+        pair_id=ETH_PAIR,
+        source=SOURCE_1,
+        publisher=PUBLISHER_NAME,
+        price=1000,
+        timestamp=int(time.time()),
+    ),
+    SpotEntry(
+        pair_id=ETH_PAIR,
+        source=SOURCE_2,
+        publisher=PUBLISHER_NAME,
+        price=1000,
+        timestamp=int(time.time()),
+    ),
+]
 
 EMPTY_DATA = [
-        SpotEntry(
-            pair_id="pair_id",
-            source="source",
-            publisher="publisher",
-            price=0,
-            timestamp=0,
-            volume=0,
-            autoscale_volume=False
-        ),
-    ]
+    SpotEntry(
+        pair_id="pair_id",
+        source="source",
+        publisher="publisher",
+        price=0,
+        timestamp=0,
+        volume=0,
+        autoscale_volume=False,
+    ),
+]
+
 
 @pytest_asyncio.fixture(scope="package", name="pragma_offchain_client")
 async def pragma_offchain_client(
@@ -59,10 +60,12 @@ async def pragma_offchain_client(
         account_private_key=private_key,
     )
 
+
 def test_publish_message():
     msg = build_publish_message(MOCK_DATA)
     hash_ = TypedData.from_dict(msg).message_hash(0)
     print(msg, hash_)
+
 
 def test_publish_message_empty():
     msg = build_publish_message(EMPTY_DATA)
@@ -77,6 +80,7 @@ async def test_publish_api(pragma_offchain_client: PragmaClient):
 
     assert response.number_entries_created == 2
 
+
 @pytest.mark.asyncio
 # pylint: disable=redefined-outer-name
 async def test_get_data(pragma_offchain_client: PragmaClient):
@@ -84,5 +88,5 @@ async def test_get_data(pragma_offchain_client: PragmaClient):
     print(response)
 
     assert response["num_sources_aggregated"] > 0
-    assert response["pair_id"] == 'ETH/USD'
+    assert response["pair_id"] == "ETH/USD"
     assert response["price"] > 0

--- a/stagecoach/jobs/tests/test_checkpoint.py
+++ b/stagecoach/jobs/tests/test_checkpoint.py
@@ -1,5 +1,6 @@
-import pytest
 import os
+
+import pytest
 from starknet_py.net.client_models import TransactionType
 
 from pragma.tests.constants import TESTNET_ACCOUNT_ADDRESS, TESTNET_ACCOUNT_PRIVATE_KEY

--- a/stagecoach/jobs/tests/test_custom.py
+++ b/stagecoach/jobs/tests/test_custom.py
@@ -1,5 +1,6 @@
-import pytest
 import os
+
+import pytest
 
 from pragma.tests.constants import (
     SAMPLE_ASSETS,
@@ -14,7 +15,9 @@ from stagecoach.jobs.publishers.custom import app
 def mock_custom_env(monkeypatch):
     env_vars = {
         "PUBLISHER_PRIVATE_KEY": int(os.environ["PUBLISHER_PRIVATE_KEY"], 10),
-        "PUBLISHER_ADDRESS": int("0x0624EBFB99865079BD58CFCFB925B6F5CE940D6F6E41E118B8A72B7163FB435C", 16),
+        "PUBLISHER_ADDRESS": int(
+            "0x0624EBFB99865079BD58CFCFB925B6F5CE940D6F6E41E118B8A72B7163FB435C", 16
+        ),
         "NETWORK": "devnet",
         # default max_fee of 1e18 wei triggers a code 54 error (account balance < tx.max_fee)
         "MAX_FEE": int(1e16),

--- a/stagecoach/jobs/tests/test_starknet_publisher.py
+++ b/stagecoach/jobs/tests/test_starknet_publisher.py
@@ -9,13 +9,13 @@ from aioresponses import aioresponses
 from pragma.tests.constants import (
     SAMPLE_ASSETS,
     SAMPLE_FUTURE_ASSETS,
-    TESTNET_ACCOUNT_PRIVATE_KEY,
     TESTNET_ACCOUNT_ADDRESS,
+    TESTNET_ACCOUNT_PRIVATE_KEY,
 )
 from pragma.tests.fetcher_configs import (
     FETCHER_CONFIGS,
-    ONCHAIN_FETCHER_CONFIGS,
     FUTURE_FETCHER_CONFIGS,
+    ONCHAIN_FETCHER_CONFIGS,
 )
 
 
@@ -27,7 +27,9 @@ def mock_starknet_publisher_env(monkeypatch):
         "SPOT_ASSETS": SAMPLE_ASSETS,
         "FUTURE_ASSETS": SAMPLE_FUTURE_ASSETS,
         "PUBLISHER": "PRAGMA",
-        "PUBLISHER_ADDRESS": int("0x0624EBFB99865079BD58CFCFB925B6F5CE940D6F6E41E118B8A72B7163FB435C", 16),
+        "PUBLISHER_ADDRESS": int(
+            "0x0624EBFB99865079BD58CFCFB925B6F5CE940D6F6E41E118B8A72B7163FB435C", 16
+        ),
         "PUBLISHER_PRIVATE_KEY": int(os.environ["PUBLISHER_PRIVATE_KEY"]),
         "KAIKO_API_KEY": "some_key",
         "PAGINATION": 40,


### PR DESCRIPTION
Solves #37 

Adds basic support for fetching `SpotEntry` USD pairs from Uniswap V3 through TheGraph.

Future Action Items
--
- [ ] Adapt existing fetchers to support pairs with `ETH` as `base_asset` 
- [ ] Abstract `TheGraphFetcher` and create `UniswapV2`/`UniswapV3` Fetchers instead
- [ ] Fix `fetcher_sync_success` for `TheGraphFetcher`