### PR TITLE
✨ add timestamp/expiry to publish msg

### DIFF
--- a/stagecoach/jobs/publishers/checkpoint/app.py
+++ b/stagecoach/jobs/publishers/checkpoint/app.py
@@ -16,7 +16,7 @@ NETWORK = os.environ["NETWORK"]
 ASSETS = os.environ["ASSETS"]
 ASSET_TYPE = os.environ.get("ASSET_TYPE", "SPOT")
 ACCOUNT_ADDRESS = int(os.environ.get("ACCOUNT_ADDRESS"), 16)
-MAX_FEE = int(os.environ.get("MAX_FEE", int(1e18)))
+MAX_FEE = int(os.environ.get("MAX_FEE", int(1e17)))
 
 
 def handler(event, context):
@@ -39,7 +39,7 @@ def _get_pvt_key():
     get_secret_value_response = client.get_secret_value(SecretId=SECRET_NAME)
     return int(
         json.loads(get_secret_value_response["SecretString"])["PUBLISHER_PRIVATE_KEY"],
-        10,
+        16,
     )
 
 

--- a/stagecoach/jobs/publishers/starknet_publisher/app.py
+++ b/stagecoach/jobs/publishers/starknet_publisher/app.py
@@ -33,7 +33,7 @@ SECRET_NAME = os.environ["SECRET_NAME"]
 SPOT_ASSETS = os.environ["SPOT_ASSETS"]
 FUTURE_ASSETS = os.environ["FUTURE_ASSETS"]
 PUBLISHER = os.environ.get("PUBLISHER")
-PUBLISHER_ADDRESS = int(os.environ.get("PUBLISHER_ADDRESS"), 0)
+PUBLISHER_ADDRESS = int(os.environ.get("PUBLISHER_ADDRESS"), 16)
 KAIKO_API_KEY = os.environ.get("KAIKO_API_KEY")
 PAGINATION = os.environ.get("PAGINATION")
 RPC_URL = os.environ.get("RPC_URL")
@@ -65,13 +65,13 @@ def _get_pvt_key():
     get_secret_value_response = client.get_secret_value(SecretId=SECRET_NAME)
     return int(
         json.loads(get_secret_value_response["SecretString"])["PUBLISHER_PRIVATE_KEY"],
-        0,
+        16,
     )
 
 
 async def _handler(assets):
     publisher_private_key = _get_pvt_key()
-    # publisher_private_key = int(os.environ.get("PUBLISHER_PRIVATE_KEY"), 0)
+    # publisher_private_key = int(os.environ.get("PUBLISHER_PRIVATE_KEY"), 16)
 
     rpc_url = os.getenv("RPC_URL")
 

--- a/stagecoach/jobs/randomness/app.py
+++ b/stagecoach/jobs/randomness/app.py
@@ -4,9 +4,9 @@ import os
 from pragma.core.client import PragmaClient
 
 START_BLOCK = int(os.environ.get("START_BLOCK", 0))
-NETWORK = os.environ.get("NETWORK", "testnet")
-ADMIN_PRIVATE_KEY = int(os.environ["ADMIN_PRIVATE_KEY"], 0)
-ADMIN_CONTRACT_ADDRESS = int(os.environ["ADMIN_CONTRACT_ADDRESS"], 0)
+NETWORK = os.environ.get("NETWORK", "sepolia")
+ADMIN_PRIVATE_KEY = int(os.environ["ADMIN_PRIVATE_KEY"], 16)
+ADMIN_CONTRACT_ADDRESS = int(os.environ["ADMIN_CONTRACT_ADDRESS"], 16)
 VRF_CONTRACT_ADDRESS = int(os.environ["VRF_CONTRACT_ADDRESS"], 16)
 
 


### PR DESCRIPTION
In order to prevent replay attacks, we add the timestamp and expiration parameters to the signed message. It's also sent through the headers so the API can reconstruct the message and verify the signature.