### PR TITLE
hotfix: Chain name in services

### DIFF
--- a/price-pusher/price_pusher/main.py
+++ b/price-pusher/price_pusher/main.py
@@ -136,6 +136,7 @@ def _create_client(
             auto_estimate=True,
         )
         return PragmaOnChainClient(
+            chain_name=network,
             network=network if rpc_url is None else rpc_url,
             account_contract_address=publisher_address,
             account_private_key=private_key,

--- a/vrf-listener/vrf_listener/main.py
+++ b/vrf-listener/vrf_listener/main.py
@@ -26,10 +26,10 @@ async def main(
 ) -> None:
     logger.info("🧩 Starting VRF listener...")
     client = PragmaOnChainClient(
+        chain_name=network,
         network=network if rpc_url is None else rpc_url,
         account_contract_address=int(admin_address, 16),
         account_private_key=int(private_key, 16),
-        chain_name=network,
         contract_addresses_config=ContractAddresses(
             publisher_registry_address=0x0,
             oracle_proxy_addresss=int(oracle_address, 16),


### PR DESCRIPTION
Closes # 

## Introduced changes
- Fixed error for when the network is an RPC_URL, missed the chain_name

