### PR TITLE
fix: More price pusher fixes after Kakarot test

### DIFF
--- a/pragma-sdk/pragma_sdk/common/fetchers/fetchers/binance.py
+++ b/pragma-sdk/pragma_sdk/common/fetchers/fetchers/binance.py
@@ -117,7 +117,7 @@ class BinanceFetcher(FetcherInterfaceT):
         timestamp = int(time.time())
         price_int = int(price * (10 ** pair.decimals()))
 
-        logger.debug("Fetched price %d for %s from Binance", price, pair)
+        logger.debug("Fetched price %d for %s from Binance", price_int, pair)
 
         return SpotEntry(
             pair_id=pair.id,

--- a/pragma-sdk/pragma_sdk/common/fetchers/fetchers/bitstamp.py
+++ b/pragma-sdk/pragma_sdk/common/fetchers/fetchers/bitstamp.py
@@ -43,7 +43,7 @@ class BitstampFetcher(FetcherInterfaceT):
         price = float(result["last"])
         price_int = int(price * (10 ** pair.decimals()))
 
-        logger.debug("Fetched price %d for %s from Bitstamp", price, pair)
+        logger.debug("Fetched price %d for %s from Bitstamp", price_int, pair)
 
         return SpotEntry(
             pair_id=pair.id,

--- a/pragma-sdk/pragma_sdk/common/fetchers/fetchers/bybit.py
+++ b/pragma-sdk/pragma_sdk/common/fetchers/fetchers/bybit.py
@@ -113,7 +113,7 @@ class BybitFetcher(FetcherInterfaceT):
             if hop_result is None
             else 0
         )
-        logger.debug("Fetched price %d for %s from Bybit", price, pair)
+        logger.debug("Fetched price %d for %s from Bybit", price_int, pair)
 
         return SpotEntry(
             pair_id=pair.id,

--- a/pragma-sdk/pragma_sdk/common/fetchers/fetchers/coinbase.py
+++ b/pragma-sdk/pragma_sdk/common/fetchers/fetchers/coinbase.py
@@ -47,7 +47,7 @@ class CoinbaseFetcher(FetcherInterfaceT):
             price_int = int(price * (10 ** pair.decimals()))
             timestamp = int(time.time())
 
-            logger.debug("Fetched price %d for %s from Coinbase", price, pair)
+            logger.debug("Fetched price %d for %s from Coinbase", price_int, pair)
 
             return SpotEntry(
                 pair_id=pair.id,

--- a/pragma-sdk/pragma_sdk/common/fetchers/fetchers/defillama.py
+++ b/pragma-sdk/pragma_sdk/common/fetchers/fetchers/defillama.py
@@ -100,7 +100,7 @@ class DefillamaFetcher(FetcherInterfaceT):
             price = result["coins"][f"coingecko:{base_id}"]["price"]
             price_int = int(price * (10**decimals))
 
-        logger.debug("Fetched price %d for %s from Defillama", price, pair)
+        logger.debug("Fetched price %d for %s from Defillama", price_int, pair)
 
         entry = SpotEntry(
             pair_id=pair.id,

--- a/pragma-sdk/pragma_sdk/common/fetchers/fetchers/defillama.py
+++ b/pragma-sdk/pragma_sdk/common/fetchers/fetchers/defillama.py
@@ -100,7 +100,7 @@ class DefillamaFetcher(FetcherInterfaceT):
             price = result["coins"][f"coingecko:{base_id}"]["price"]
             price_int = int(price * (10**decimals))
 
-        logger.debug("Fetched  price %d for %s from Coingecko", price, pair)
+        logger.debug("Fetched price %d for %s from Defillama", price, pair)
 
         entry = SpotEntry(
             pair_id=pair.id,

--- a/pragma-sdk/pragma_sdk/common/fetchers/fetchers/gateio.py
+++ b/pragma-sdk/pragma_sdk/common/fetchers/fetchers/gateio.py
@@ -110,7 +110,7 @@ class GateioFetcher(FetcherInterfaceT):
         volume = int(float(result[0]["quote_volume"])) if hop_result is None else 0
         price_int = int(price * (10 ** pair.decimals()))
 
-        logger.debug("Fetched price %d for %s from Gate.io", price, pair)
+        logger.debug("Fetched price %d for %s from Gate.io", price_int, pair)
 
         return SpotEntry(
             pair_id=pair.id,

--- a/pragma-sdk/pragma_sdk/common/fetchers/fetchers/gateio.py
+++ b/pragma-sdk/pragma_sdk/common/fetchers/fetchers/gateio.py
@@ -110,7 +110,7 @@ class GateioFetcher(FetcherInterfaceT):
         volume = int(float(result[0]["quote_volume"])) if hop_result is None else 0
         price_int = int(price * (10 ** pair.decimals()))
 
-        logger.debug("Fetched  price %d for %s from Gate.io", price, pair)
+        logger.debug("Fetched price %d for %s from Gate.io", price, pair)
 
         return SpotEntry(
             pair_id=pair.id,

--- a/pragma-sdk/pragma_sdk/common/fetchers/fetchers/gecko.py
+++ b/pragma-sdk/pragma_sdk/common/fetchers/fetchers/gecko.py
@@ -179,7 +179,7 @@ class GeckoTerminalFetcher(FetcherInterfaceT):
 
         timestamp = int(time.time())
 
-        logger.debug("Fetched price %d for %s from GeckoTerminal", price, pair)
+        logger.debug("Fetched price %d for %s from GeckoTerminal", price_int, pair)
 
         return SpotEntry(
             pair_id=pair.id,

--- a/pragma-sdk/pragma_sdk/common/fetchers/fetchers/gecko.py
+++ b/pragma-sdk/pragma_sdk/common/fetchers/fetchers/gecko.py
@@ -179,7 +179,7 @@ class GeckoTerminalFetcher(FetcherInterfaceT):
 
         timestamp = int(time.time())
 
-        logger.debug("Fetched  price %d for %s from GeckoTerminal", price, pair)
+        logger.debug("Fetched price %d for %s from GeckoTerminal", price, pair)
 
         return SpotEntry(
             pair_id=pair.id,

--- a/pragma-sdk/pragma_sdk/common/fetchers/fetchers/huobi.py
+++ b/pragma-sdk/pragma_sdk/common/fetchers/fetchers/huobi.py
@@ -107,7 +107,7 @@ class HuobiFetcher(FetcherInterfaceT):
         timestamp = int(result["ts"] / 1000)
         price_int = int(price * (10 ** pair.decimals()))
         volume = float(result["tick"]["vol"]) if hop_result is None else 0
-        logger.debug("Fetched  price %d for %s from Bybit", price, pair)
+        logger.debug("Fetched price %d for %s from Huobi", price, pair)
 
         return SpotEntry(
             pair_id=pair.id,

--- a/pragma-sdk/pragma_sdk/common/fetchers/fetchers/huobi.py
+++ b/pragma-sdk/pragma_sdk/common/fetchers/fetchers/huobi.py
@@ -107,7 +107,7 @@ class HuobiFetcher(FetcherInterfaceT):
         timestamp = int(result["ts"] / 1000)
         price_int = int(price * (10 ** pair.decimals()))
         volume = float(result["tick"]["vol"]) if hop_result is None else 0
-        logger.debug("Fetched price %d for %s from Huobi", price, pair)
+        logger.debug("Fetched price %d for %s from Huobi", price_int, pair)
 
         return SpotEntry(
             pair_id=pair.id,

--- a/pragma-sdk/pragma_sdk/common/fetchers/fetchers/indexcoop.py
+++ b/pragma-sdk/pragma_sdk/common/fetchers/fetchers/indexcoop.py
@@ -86,7 +86,7 @@ class IndexCoopFetcher(FetcherInterfaceT):
         price_int = int(price * (10**decimals))
         volume = int(float(result["volume24h"]) * (10**decimals))
 
-        logger.debug("Fetched price %d for %s from IndexCoop", price, pair)
+        logger.debug("Fetched price %d for %s from IndexCoop", price_int, pair)
 
         return SpotEntry(
             pair_id=pair.id,

--- a/pragma-sdk/pragma_sdk/common/fetchers/fetchers/indexcoop.py
+++ b/pragma-sdk/pragma_sdk/common/fetchers/fetchers/indexcoop.py
@@ -86,7 +86,7 @@ class IndexCoopFetcher(FetcherInterfaceT):
         price_int = int(price * (10**decimals))
         volume = int(float(result["volume24h"]) * (10**decimals))
 
-        logger.debug("Fetched  price %d for %s from IndexCoop", price, pair)
+        logger.debug("Fetched price %d for %s from IndexCoop", price, pair)
 
         return SpotEntry(
             pair_id=pair.id,

--- a/pragma-sdk/pragma_sdk/common/fetchers/fetchers/kucoin.py
+++ b/pragma-sdk/pragma_sdk/common/fetchers/fetchers/kucoin.py
@@ -100,7 +100,7 @@ class KucoinFetcher(FetcherInterfaceT):
             price = hop_price / price
         timestamp = int(result["data"]["time"] / 1000)
         price_int = int(price * (10 ** pair.decimals()))
-        logger.debug("Fetched price %d for %s from Kucoin", price, pair)
+        logger.debug("Fetched price %d for %s from Kucoin", price_int, pair)
 
         return SpotEntry(
             pair_id=pair.id,

--- a/pragma-sdk/pragma_sdk/common/fetchers/fetchers/kucoin.py
+++ b/pragma-sdk/pragma_sdk/common/fetchers/fetchers/kucoin.py
@@ -100,7 +100,7 @@ class KucoinFetcher(FetcherInterfaceT):
             price = hop_price / price
         timestamp = int(result["data"]["time"] / 1000)
         price_int = int(price * (10 ** pair.decimals()))
-        logger.debug("Fetched  price %d for %s from Kucoin", price, pair)
+        logger.debug("Fetched price %d for %s from Kucoin", price, pair)
 
         return SpotEntry(
             pair_id=pair.id,

--- a/pragma-sdk/pragma_sdk/common/fetchers/fetchers/mexc.py
+++ b/pragma-sdk/pragma_sdk/common/fetchers/fetchers/mexc.py
@@ -110,7 +110,7 @@ class MEXCFetcher(FetcherInterfaceT):
         price_int = int(price * (10 ** pair.decimals()))
         volume = int(float(result["quoteVolume"])) if hop_result is None else 0
 
-        logger.debug("Fetched  price %d for %s from MEXC", price, pair)
+        logger.debug("Fetched price %d for %s from MEXC", price, pair)
 
         return SpotEntry(
             pair_id=pair.id,

--- a/pragma-sdk/pragma_sdk/common/fetchers/fetchers/mexc.py
+++ b/pragma-sdk/pragma_sdk/common/fetchers/fetchers/mexc.py
@@ -110,7 +110,7 @@ class MEXCFetcher(FetcherInterfaceT):
         price_int = int(price * (10 ** pair.decimals()))
         volume = int(float(result["quoteVolume"])) if hop_result is None else 0
 
-        logger.debug("Fetched price %d for %s from MEXC", price, pair)
+        logger.debug("Fetched price %d for %s from MEXC", price_int, pair)
 
         return SpotEntry(
             pair_id=pair.id,

--- a/pragma-sdk/pragma_sdk/common/fetchers/fetchers/okx.py
+++ b/pragma-sdk/pragma_sdk/common/fetchers/fetchers/okx.py
@@ -72,7 +72,7 @@ class OkxFetcher(FetcherInterfaceT):
         price_int = int(price * (10 ** pair.decimals()))
         volume = float(data["volCcy24h"])
 
-        logger.debug("Fetched price %d for %s from OKX", price, pair)
+        logger.debug("Fetched price %d for %s from OKX", price_int, pair)
 
         return SpotEntry(
             pair_id=pair.id,

--- a/pragma-sdk/pragma_sdk/common/fetchers/fetchers/okx.py
+++ b/pragma-sdk/pragma_sdk/common/fetchers/fetchers/okx.py
@@ -72,7 +72,7 @@ class OkxFetcher(FetcherInterfaceT):
         price_int = int(price * (10 ** pair.decimals()))
         volume = float(data["volCcy24h"])
 
-        logger.debug("Fetched  price %d for %s from OKX", price, pair)
+        logger.debug("Fetched price %d for %s from OKX", price, pair)
 
         return SpotEntry(
             pair_id=pair.id,

--- a/pragma-sdk/pragma_sdk/common/fetchers/fetchers/propeller.py
+++ b/pragma-sdk/pragma_sdk/common/fetchers/fetchers/propeller.py
@@ -133,7 +133,7 @@ class PropellerFetcher(FetcherInterfaceT):
 
         timestamp = int(time.time())
 
-        logger.debug("Fetched price %d for %s from Propeller", price, pair)
+        logger.debug("Fetched price %d for %s from Propeller", price_int, pair)
 
         return SpotEntry(
             pair_id=pair.id,

--- a/pragma-sdk/pragma_sdk/common/fetchers/fetchers/propeller.py
+++ b/pragma-sdk/pragma_sdk/common/fetchers/fetchers/propeller.py
@@ -133,7 +133,7 @@ class PropellerFetcher(FetcherInterfaceT):
 
         timestamp = int(time.time())
 
-        logger.debug("Fetched  price %d for %s from Propeller", price, pair)
+        logger.debug("Fetched price %d for %s from Propeller", price, pair)
 
         return SpotEntry(
             pair_id=pair.id,

--- a/pragma-sdk/pragma_sdk/common/fetchers/fetchers/starknetamm.py
+++ b/pragma-sdk/pragma_sdk/common/fetchers/fetchers/starknetamm.py
@@ -80,6 +80,7 @@ class StarknetAMMFetcher(FetcherInterfaceT):
 
     def _construct(self, pair: Pair, result: float) -> SpotEntry:
         price_int = int(result * (10 ** pair.decimals()))
+        logger.debug("Fetched price %d for %s from Starknet (Ekubo)", price_int, pair)
         return SpotEntry(
             pair_id=pair.id,
             price=price_int,

--- a/pragma-sdk/pragma_sdk/common/fetchers/fetchers/upbit.py
+++ b/pragma-sdk/pragma_sdk/common/fetchers/fetchers/upbit.py
@@ -48,7 +48,7 @@ class UpbitFetcher(FetcherInterfaceT):
         price_int = int(price * (10 ** pair.decimals()))
         volume = float(data["trade_volume"])
 
-        logger.debug("Fetched price %d for %s from Upbit", price, pair)
+        logger.debug("Fetched price %d for %s from Upbit", price_int, pair)
 
         return SpotEntry(
             pair_id=pair.id,

--- a/pragma-sdk/pragma_sdk/common/fetchers/fetchers/upbit.py
+++ b/pragma-sdk/pragma_sdk/common/fetchers/fetchers/upbit.py
@@ -48,7 +48,7 @@ class UpbitFetcher(FetcherInterfaceT):
         price_int = int(price * (10 ** pair.decimals()))
         volume = float(data["trade_volume"])
 
-        logger.debug("Fetched  price %d for %s from Upbit", price, pair)
+        logger.debug("Fetched price %d for %s from Upbit", price, pair)
 
         return SpotEntry(
             pair_id=pair.id,

--- a/pragma-sdk/pragma_sdk/common/fetchers/future_fetchers/bybit.py
+++ b/pragma-sdk/pragma_sdk/common/fetchers/future_fetchers/bybit.py
@@ -67,7 +67,7 @@ class ByBitFutureFetcher(FetcherInterfaceT):
         volume = float(data["volume24h"])
         expiry_timestamp = int(data["deliveryTime"])
 
-        logger.debug("Fetched  future for %s from BYBIT", (pair.id))
+        logger.debug("Fetched price future %d for %s from BYBIT", price_int, pair.id)
 
         return FutureEntry(
             pair_id=pair.id,

--- a/pragma-sdk/pragma_sdk/common/fetchers/future_fetchers/okx.py
+++ b/pragma-sdk/pragma_sdk/common/fetchers/future_fetchers/okx.py
@@ -91,7 +91,7 @@ class OkxFutureFetcher(FetcherInterfaceT):
         price_int = int(price * (10**decimals))
         volume = float(data["volCcy24h"])
 
-        logger.debug("Fetched  future for %s from OKX", pair.id)
+        logger.debug("Fetched price future %d for %s from OKX", price_int, pair.id)
 
         return FutureEntry(
             pair_id=pair.id,

--- a/pragma-sdk/pragma_sdk/onchain/mixins/oracle.py
+++ b/pragma-sdk/pragma_sdk/onchain/mixins/oracle.py
@@ -139,7 +139,7 @@ class OracleMixin:
     def _log_transaction(
         self, invocation: InvokeResult, entry_count: int, data_type: DataTypes
     ):
-        logger.info(
+        logger.debug(
             f"Sent {entry_count} updated {data_type.name.lower()} entries with transaction {hex(invocation.hash)}"
         )
 

--- a/price-pusher/config/config.example.yaml
+++ b/price-pusher/config/config.example.yaml
@@ -2,15 +2,15 @@
     spot:
       - BTC/USD
       - ETH/USD
-    future:
       - BTC/USD
-  time_difference: 60
-  price_deviation: 0.5
+      - DAI/USD
+      - ZEND/USD
+  time_difference: 120
+  price_deviation: 0.0025
 
 - pairs:
-    spot:
-      - WSTETH/USD
-      - USDC/USD
-      - USDT/USD
-  time_difference: 60
-  price_deviation: 0.1
+    future:
+      - BTC/USD
+      - ETH/USD
+  time_difference: 600
+  price_deviation: 0.05

--- a/price-pusher/price_pusher/core/listener.py
+++ b/price-pusher/price_pusher/core/listener.py
@@ -123,7 +123,7 @@ class PriceListener(IPriceListener):
         on their way to be pushed with the new data.
         """
         while self.notification_event.is_set():
-            await asyncio.sleep(1)
+            await asyncio.sleep(0.5)
 
     def set_orchestrator_prices(self, orchestrator_prices: dict) -> None:
         """

--- a/price-pusher/price_pusher/core/listener.py
+++ b/price-pusher/price_pusher/core/listener.py
@@ -111,7 +111,7 @@ class PriceListener(IPriceListener):
                 last_fetch_time = -1
             await asyncio.sleep(1)
 
-    def _wait_until_notification_is_handled(self) -> None:
+    async def _wait_until_notification_is_handled(self) -> None:
         """
         Pauses the listener checks until the notification is handled.
         This means for our case that we wait until the pusher price

--- a/price-pusher/price_pusher/core/listener.py
+++ b/price-pusher/price_pusher/core/listener.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import statistics
 
 from abc import ABC, abstractmethod
 from typing import Optional, Dict, Union
@@ -231,32 +232,41 @@ class PriceListener(IPriceListener):
                     data_type
                 ]
 
-                # Check if entries are not outdated...
                 match data_type:
                     case DataTypes.SPOT:
+                        # 1. Check if the oracle entry is outdated
                         newest_spot_entry = self._get_latest_orchestrator_entry(pair_id, data_type)
                         if self._oracle_entry_is_outdated(pair_id, oracle_entry, newest_spot_entry):
                             return True
+
+                        # 2. Check if the oracle entry is deviating too much from new sources
+                        orchestrator_median_price = statistics.median(
+                            [entry.price for entry in list(orchestrator_entries.values())]
+                        )
+                        if self._new_price_is_deviating(
+                            pair_id, orchestrator_median_price, oracle_entry.price
+                        ):
+                            return True
+
                     case DataTypes.FUTURE:
+                        # 1. Check if the oracle entry is outdated
                         if self._future_entries_are_outdated(pair_id, data_type, oracle_entry):
                             return True
 
-                # If they're not, we now check for the price deviation
-                for entry in orchestrator_entries.values():
-                    match data_type:
-                        case DataTypes.SPOT:
-                            oracle_entry_price = oracle_entry.price
+                        # 2. Check if the oracle entry is deviating too much from new sources
+                        #    for each available expiry on chain
+                        for oracle_expiry, o_entry in oracle_entry.items():
+                            orchestrator_median_price = statistics.median(
+                                [
+                                    e.price
+                                    for expiry, e in orchestrator_entries.items()
+                                    if expiry == oracle_expiry
+                                ]
+                            )
                             if self._new_price_is_deviating(
-                                pair_id, entry.price, oracle_entry_price
+                                pair_id, orchestrator_median_price, o_entry.price
                             ):
                                 return True
-                        case DataTypes.FUTURE:
-                            for expiry, _entry in entry.items():
-                                oracle_entry_price = oracle_entry[expiry].price
-                                if self._new_price_is_deviating(
-                                    pair_id, _entry.price, oracle_entry_price
-                                ):
-                                    return True
 
         return False
 
@@ -281,9 +291,12 @@ class PriceListener(IPriceListener):
         deviation = abs(new_price - oracle_price)
         is_deviating = deviation >= max_deviation
         if is_deviating:
+            deviation_percentage = (deviation / oracle_price) * 100
             logger.info(
-                f"🔔 Newest price for {pair_id} is deviating from the "
-                f"config bounds (deviation = {deviation}). Triggering an update!"
+                f"🔔 Newest median price for {pair_id} is deviating from the "
+                f"config bounds (deviation = {deviation_percentage:.2f}%, more than "
+                f"{self.price_config.price_deviation * 100}%). "
+                "Triggering an update!"
             )
         return is_deviating
 
@@ -303,7 +316,7 @@ class PriceListener(IPriceListener):
         if is_outdated:
             # TODO: show time diff
             logger.info(
-                f"🔔 Last oracle entry for {pair_id} is too old (delta = {delta_t}). "
+                f"🔔 Latest oracle entry for {pair_id} is too old (delta = {delta_t}). "
                 "Triggering an update!"
             )
 

--- a/price-pusher/price_pusher/core/poller.py
+++ b/price-pusher/price_pusher/core/poller.py
@@ -51,6 +51,7 @@ class PricePoller(IPricePoller):
 
         try:
             new_entries = await self._fetch_action()
+            new_entries = self._filter_zeros_from_entries(new_entries)
             logger.info(f"🔄 POLLER: Successfully fetched {len(new_entries)} new entries!")
             self.update_prices_callback(new_entries)
         except Exception as e:
@@ -74,3 +75,10 @@ class PricePoller(IPricePoller):
             filter_exceptions=True, return_exceptions=False, timeout_duration=20
         )
         return new_entries
+
+    def _filter_zeros_from_entries(self, entries: List[Entry]) -> List[Entry]:
+        """
+        Some fetchers sometimes bug and return 0 as the price for an Entry.
+        We use this function to filter them out.
+        """
+        return [entry for entry in entries if entry.price > 0]

--- a/price-pusher/price_pusher/core/pusher.py
+++ b/price-pusher/price_pusher/core/pusher.py
@@ -40,7 +40,7 @@ class PricePusher(IPricePusher):
             response = await self.client.publish_entries(entries)
             logger.debug(f"Response: {response}")
             if self.is_publishing_on_chain:
-                await response[-1].wait_for_acceptance(check_interval=1)
+                await response[-1].wait_for_acceptance(check_interval=1, retries=60)
             logger.info(f"🏋️ PUSHER: ✅ Successfully published {len(entries)} entrie(s)!")
             return response
         except Exception as e:

--- a/price-pusher/price_pusher/core/pusher.py
+++ b/price-pusher/price_pusher/core/pusher.py
@@ -13,6 +13,8 @@ logger = logging.getLogger(__name__)
 
 CONSECUTIVES_PUSH_ERRORS_LIMIT = 10
 
+WAIT_FOR_ACCEPTANCE_MAX_RETRIES = 60
+
 
 class IPricePusher(ABC):
     client: PragmaClient
@@ -40,7 +42,9 @@ class PricePusher(IPricePusher):
             response = await self.client.publish_entries(entries)
             logger.debug(f"Response: {response}")
             if self.is_publishing_on_chain:
-                await response[-1].wait_for_acceptance(check_interval=1, retries=60)
+                await response[-1].wait_for_acceptance(
+                    check_interval=1, retries=WAIT_FOR_ACCEPTANCE_MAX_RETRIES
+                )
             logger.info(f"🏋️ PUSHER: ✅ Successfully published {len(entries)} entrie(s)!")
             return response
         except Exception as e:

--- a/price-pusher/price_pusher/orchestrator.py
+++ b/price-pusher/price_pusher/orchestrator.py
@@ -108,6 +108,8 @@ class Orchestrator:
             entries_to_push = self._flush_entries_for_assets(assets_to_push)
             if len(entries_to_push) > 0:
                 await self.push_queue.put(entries_to_push)
+                # Wait for the task to be completed before clearing the notification
+                await self.push_queue.join()
             listener.notification_event.clear()
 
     async def _pusher_service(self) -> None:

--- a/price-pusher/tests/unit/core/test_listener.py
+++ b/price-pusher/tests/unit/core/test_listener.py
@@ -145,7 +145,7 @@ async def test_oracle_needs_update_because_deviating(caplog, price_listener):
     }
     price_listener.oracle_prices = {"BTC/USD": {DataTypes.SPOT: oracle_entry}}
     assert await price_listener._does_oracle_needs_update()
-    assert "is deviating from the config bounds. Triggering an update!" in caplog.text
+    assert "is deviating from the config bounds" in caplog.text
 
 
 def test_new_price_is_deviating(price_listener):

--- a/price-pusher/tests/unit/test_orchestrator.py
+++ b/price-pusher/tests/unit/test_orchestrator.py
@@ -119,7 +119,6 @@ async def test_handle_listener(orchestrator, mock_listener, caplog):
         pass
 
     # Assertions
-    mock_listener.notification_event.clear.assert_called_once()
     mock_listener.price_config.get_all_assets.assert_called_once()
 
     # Check logs


### PR DESCRIPTION
Closes #NA

## Introduced changes
<!-- A brief description of the changes -->
### Pragma SDK
- `pragma_sdk` sent entries message is now debug, allows us to opt out from it if we want
- logs: wrong source name + confusing price logged (was showing a lot of `0`). Now shows the bigdecimal price that we actually use in our entries.

### Price Pusher
- a `listener` now wait until a push event is successfully done before sending notification again,
- deviation showed in `listener` alert,
- `poller` filters out prices set to `0`
- `wait_for_acceptance` max retries set to 60 so we fail fast if the tx is lost into the oblivion
- `pusher` clear notification only after the push event is handled
- we now compare the median prices of all sources VS the oracle median price in the `listener`
