### PR TITLE
fix: Price pusher median comparison

### DIFF
--- a/pragma-sdk/pragma_sdk/common/types/entry.py
+++ b/pragma-sdk/pragma_sdk/common/types/entry.py
@@ -213,7 +213,7 @@ class SpotEntry(Entry):
         return felt_to_str(self.pair_id)
 
     def get_source(self) -> str:
-        return felt_to_str(self.base.source).upper()
+        return felt_to_str(self.base.source)
 
     def get_asset_type(self) -> DataTypes:
         return DataTypes.SPOT
@@ -406,7 +406,7 @@ class FutureEntry(Entry):
         return felt_to_str(self.pair_id)
 
     def get_source(self) -> str:
-        return felt_to_str(self.base.source).upper()
+        return felt_to_str(self.base.source)
 
     def get_asset_type(self) -> DataTypes:
         return DataTypes.FUTURE
@@ -562,7 +562,7 @@ class GenericEntry(Entry):
         return felt_to_str(self.key)
 
     def get_source(self) -> str:
-        return felt_to_str(self.base.source).upper()
+        return felt_to_str(self.base.source)
 
     def get_asset_type(self) -> DataTypes:
         return DataTypes.GENERIC

--- a/pragma-sdk/pragma_sdk/common/types/entry.py
+++ b/pragma-sdk/pragma_sdk/common/types/entry.py
@@ -213,7 +213,7 @@ class SpotEntry(Entry):
         return felt_to_str(self.pair_id)
 
     def get_source(self) -> str:
-        return felt_to_str(self.base.source)
+        return felt_to_str(self.base.source).upper()
 
     def get_asset_type(self) -> DataTypes:
         return DataTypes.SPOT
@@ -406,7 +406,7 @@ class FutureEntry(Entry):
         return felt_to_str(self.pair_id)
 
     def get_source(self) -> str:
-        return felt_to_str(self.base.source)
+        return felt_to_str(self.base.source).upper()
 
     def get_asset_type(self) -> DataTypes:
         return DataTypes.FUTURE
@@ -562,7 +562,7 @@ class GenericEntry(Entry):
         return felt_to_str(self.key)
 
     def get_source(self) -> str:
-        return felt_to_str(self.base.source)
+        return felt_to_str(self.base.source).upper()
 
     def get_asset_type(self) -> DataTypes:
         return DataTypes.GENERIC

--- a/price-pusher/price_pusher/core/listener.py
+++ b/price-pusher/price_pusher/core/listener.py
@@ -147,12 +147,29 @@ class PriceListener(IPriceListener):
         """
         self.orchestrator_prices = orchestrator_prices
 
+    def _get_sources_for_pair(self, pair: Pair, data_type: DataTypes) -> List[str]:
+        """
+        Return the sources that have entries for the pair requested in the orchestrator.
+        """
+        if self.orchestrator_prices is None:
+            return []
+        pair_id = str(pair)
+        if pair_id not in self.orchestrator_prices:
+            return []
+        if data_type not in self.orchestrator_prices[pair_id]:
+            return []
+        return list(self.orchestrator_prices[pair_id][data_type].keys())
+
     async def _fetch_all_oracle_prices(self) -> None:
         """
         Fetch the latest oracle prices for all assets in parallel.
         """
         tasks = [
-            self.request_handler.fetch_latest_entries(data_type, pair)
+            self.request_handler.fetch_latest_entries(
+                pair=pair,
+                data_type=data_type,
+                sources=self._get_sources_for_pair(pair, data_type),
+            )
             for data_type, pairs in self.data_config.items()
             for pair in pairs
         ]

--- a/price-pusher/price_pusher/core/listener.py
+++ b/price-pusher/price_pusher/core/listener.py
@@ -16,6 +16,7 @@ from price_pusher.configs import PriceConfig
 from price_pusher.core.request_handlers.interface import IRequestHandler
 from price_pusher.types import (
     DurationInSeconds,
+    LatestOraclePairPrices,
     LatestOrchestratorPairPrices,
     ExpiryTimestamp,
     SourceName,
@@ -37,6 +38,7 @@ class IPriceListener(ABC):
     request_handler: IRequestHandler
     price_config: PriceConfig
 
+    oracle_prices: LatestOraclePairPrices
     orchestrator_prices: Optional[LatestOrchestratorPairPrices]
 
     notification_event: asyncio.Event

--- a/price-pusher/price_pusher/core/request_handlers/api.py
+++ b/price-pusher/price_pusher/core/request_handlers/api.py
@@ -22,9 +22,15 @@ class APIRequestHandler(IRequestHandler):
     def __init__(self, client: PragmaAPIClient) -> None:
         self.client = client
 
-    async def fetch_latest_entries(self, data_type: DataTypes, pair: Pair) -> List[Entry]:
+    async def fetch_latest_entries(
+        self,
+        pair: Pair,
+        data_type: DataTypes,
+        sources: List[str],
+    ) -> List[Entry]:
         """
         Fetch last entry for the asset from the API.
+        NOTE: The sources parameter is not used for this handler.
         """
         if data_type is DataTypes.FUTURE:
             return await self._fetch_latest_future_entries(pair)

--- a/price-pusher/price_pusher/core/request_handlers/chain.py
+++ b/price-pusher/price_pusher/core/request_handlers/chain.py
@@ -22,14 +22,21 @@ class ChainRequestHandler(IRequestHandler):
     def __init__(self, client: PragmaOnChainClient) -> None:
         self.client = client
 
-    async def fetch_latest_entries(self, data_type: DataTypes, pair: Pair) -> List[Entry]:
-        entry = await self._fetch_oracle_price(data_type, pair)
+    async def fetch_latest_entries(
+        self,
+        pair: Pair,
+        data_type: DataTypes,
+        sources: List[str],
+    ) -> List[Entry]:
+        entry = await self._fetch_oracle_price(pair, data_type, sources)
         if entry is None:
             logger.error("Can't get price for {}: unknown asset type.")
             return None
         return entry
 
-    async def _fetch_oracle_price(self, data_type: DataTypes, pair: Pair) -> List[Entry]:
+    async def _fetch_oracle_price(
+        self, pair: Pair, data_type: DataTypes, sources: List[str]
+    ) -> List[Entry]:
         pair_id = str(pair)
 
         async def fetch_action() -> List[Entry]:
@@ -37,7 +44,9 @@ class ChainRequestHandler(IRequestHandler):
             new_entry = None
             match data_type:
                 case DataTypes.SPOT:
-                    oracle_response = await self.client.get_spot(pair_id, block_id="pending")
+                    oracle_response = await self.client.get_spot(
+                        pair_id, sources=sources, block_id="pending"
+                    )
                     new_entry = SpotEntry.from_oracle_response(
                         pair,
                         oracle_response,
@@ -46,7 +55,9 @@ class ChainRequestHandler(IRequestHandler):
                     )
                 case DataTypes.FUTURE:
                     # TODO: We only fetch the perp entry for now
-                    oracle_response = await self.client.get_future(pair_id, 0, block_id="pending")
+                    oracle_response = await self.client.get_future(
+                        pair_id, 0, sources=sources, block_id="pending"
+                    )
                     new_entry = FutureEntry.from_oracle_response(
                         pair,
                         oracle_response,

--- a/price-pusher/price_pusher/core/request_handlers/interface.py
+++ b/price-pusher/price_pusher/core/request_handlers/interface.py
@@ -1,6 +1,6 @@
 import logging
 
-from typing import List
+from typing import List, Optional
 from abc import ABC, abstractmethod
 
 from pragma_sdk.common.types.types import DataTypes
@@ -19,4 +19,9 @@ class IRequestHandler(ABC):
     client: PragmaClient
 
     @abstractmethod
-    async def fetch_latest_entries(self, data_type: DataTypes, pair: Pair) -> List[Entry]: ...
+    async def fetch_latest_entries(
+        self,
+        pair: Pair,
+        data_type: DataTypes,
+        sources: Optional[List[str]] = None,
+    ) -> List[Entry]: ...

--- a/price-pusher/tests/unit/core/test_listener.py
+++ b/price-pusher/tests/unit/core/test_listener.py
@@ -11,6 +11,10 @@ from pragma_sdk.common.types.entry import Entry, SpotEntry
 from pragma_sdk.common.types.types import DataTypes
 
 
+PUBLISHER = "PUBLISHER_1"
+SOURCE = "SOURCE_1"
+
+
 @pytest.fixture
 def mock_request_handler():
     return AsyncMock(spec=IRequestHandler)
@@ -66,12 +70,12 @@ async def test_fetch_all_oracle_prices(price_listener, mock_request_handler, moc
         pair_id="BTC/USD",
         price=10000,
         timestamp=1234567890,
-        source="SOURCE_1",
-        publisher="PUBLISHER_1",
+        source=SOURCE,
+        publisher=PUBLISHER,
     )
     mock_request_handler.fetch_latest_entries.return_value = mock_entry
 
-    price_listener.orchestrator_prices = {"BTC/USD": {DataTypes.SPOT: {"SOURCE_1": mock_entry}}}
+    price_listener.orchestrator_prices = {"BTC/USD": {DataTypes.SPOT: {SOURCE: mock_entry}}}
 
     await price_listener._fetch_all_oracle_prices()
 
@@ -79,7 +83,7 @@ async def test_fetch_all_oracle_prices(price_listener, mock_request_handler, moc
     pair = mock_price_config.get_all_assets.return_value[data_type][0]
 
     mock_request_handler.fetch_latest_entries.assert_called_once_with(
-        pair=pair, data_type=data_type, sources=["SOURCE_1"]
+        pair=pair, data_type=data_type, sources=[SOURCE]
     )
     assert "BTC/USD" in price_listener.oracle_prices
     assert DataTypes.SPOT in price_listener.oracle_prices["BTC/USD"]
@@ -91,8 +95,8 @@ def test_get_most_recent_orchestrator_entry(price_listener):
         pair_id="BTC/USD",
         price=10000,
         timestamp=1234567890,
-        source="source_1",
-        publisher="publisher_1",
+        source=SOURCE,
+        publisher=PUBLISHER,
     )
     mock_entry.base.timestamp = 1000
     price_listener.orchestrator_prices = {"BTC/USD": {DataTypes.SPOT: {"BINANCE": mock_entry}}}
@@ -108,8 +112,8 @@ async def test_oracle_needs_update_because_outdated(caplog, price_listener):
         pair_id="BTC/USD",
         price=10000,
         timestamp=1000000061,
-        source="source_1",
-        publisher="publisher_1",
+        source=SOURCE,
+        publisher=PUBLISHER,
     )
     oracle_entry = SpotEntry(
         pair_id="BTC/USD",
@@ -133,8 +137,8 @@ async def test_oracle_needs_update_because_deviating(caplog, price_listener):
         pair_id="BTC/USD",
         price=111,
         timestamp=1000000000,
-        source="source_1",
-        publisher="publisher_1",
+        source=SOURCE,
+        publisher=PUBLISHER,
     )
     oracle_entry = SpotEntry(
         pair_id="BTC/USD",

--- a/price-pusher/tests/unit/core/test_listener.py
+++ b/price-pusher/tests/unit/core/test_listener.py
@@ -66,17 +66,20 @@ async def test_fetch_all_oracle_prices(price_listener, mock_request_handler, moc
         pair_id="BTC/USD",
         price=10000,
         timestamp=1234567890,
-        source="source_1",
-        publisher="publisher_1",
+        source="SOURCE_1",
+        publisher="PUBLISHER_1",
     )
     mock_request_handler.fetch_latest_entries.return_value = mock_entry
+
+    price_listener.orchestrator_prices = {"BTC/USD": {DataTypes.SPOT: {"SOURCE_1": mock_entry}}}
+
     await price_listener._fetch_all_oracle_prices()
 
-    first_key = list(mock_price_config.get_all_assets.return_value.keys())[0]
+    data_type = list(mock_price_config.get_all_assets.return_value.keys())[0]
+    pair = mock_price_config.get_all_assets.return_value[data_type][0]
 
     mock_request_handler.fetch_latest_entries.assert_called_once_with(
-        first_key,
-        mock_price_config.get_all_assets.return_value[first_key][0],
+        pair=pair, data_type=data_type, sources=["SOURCE_1"]
     )
     assert "BTC/USD" in price_listener.oracle_prices
     assert DataTypes.SPOT in price_listener.oracle_prices["BTC/USD"]


### PR DESCRIPTION
Closes #NA

## Introduced changes
- **sdk**: `get_data_entry` onchain call + test
- **price-pusher**: `fetch_latest_entries` now takes the sources we want to compute the median for.


- [ ] This PR contains breaking changes

<!-- List of all breaking changes -->

