### PR TITLE
dev: Sync fighting + Logs

### DIFF
--- a/infra/vrf-listener/Dockerfile
+++ b/infra/vrf-listener/Dockerfile
@@ -30,4 +30,4 @@ RUN poetry install
 FROM base as final
 COPY --from=builder /opt /opt
 WORKDIR /opt/vrf-listener
-ENTRYPOINT /opt/vrf-listener/.venv/bin/python3.12 vrf_listener/main.py -n ${NETWORK} --vrf-address ${VRF_ADDRESS} --admin-address ${ADMIN_ADDRESS} --private-key ${PRIVATE_KEY} -t ${CHECK_INTERVAL} --rpc-url ${RPC_URL} --ignore-request-threshold 5 --index-with-apibara --apibara-api-key ${APIBARA_API_KEY}
+ENTRYPOINT /opt/vrf-listener/.venv/bin/python3.12 vrf_listener/main.py -n ${NETWORK} --vrf-address ${VRF_ADDRESS} --admin-address ${ADMIN_ADDRESS} --private-key ${PRIVATE_KEY} -t ${CHECK_INTERVAL} --rpc-url ${RPC_URL} --ignore-request-threshold 5

--- a/pragma-sdk/pragma_sdk/onchain/mixins/randomness.py
+++ b/pragma-sdk/pragma_sdk/onchain/mixins/randomness.py
@@ -172,7 +172,6 @@ class RandomnessMixin:
         invocation = await self.account.execute_v1(  # type: ignore[union-attr]
             calls=all_calls, max_fee=self.execution_config.max_fee
         )
-        await self.full_node_client.wait_for_tx(invocation.transaction_hash)
         return invocation
 
     async def estimate_gas_submit_random_op(

--- a/pragma-sdk/pragma_sdk/onchain/mixins/randomness.py
+++ b/pragma-sdk/pragma_sdk/onchain/mixins/randomness.py
@@ -1,6 +1,7 @@
 import asyncio
 import sys
 import multiprocessing
+import logging
 
 from typing import List, Optional, Tuple
 
@@ -10,7 +11,6 @@ from starknet_py.net.client_models import EstimatedFee
 from starknet_py.net.full_node_client import FullNodeClient
 from starknet_py.net.account.account import Account
 
-from pragma_sdk.common.logging import get_pragma_sdk_logger
 from pragma_sdk.common.randomness.utils import (
     create_randomness,
     felt_to_secret_key,
@@ -29,7 +29,7 @@ from pragma_sdk.onchain.types import (
 )
 from pragma_sdk.onchain.types.types import BlockId
 
-logger = get_pragma_sdk_logger()
+logger = logging.getLogger(__name__)
 
 
 class RandomnessMixin:
@@ -213,11 +213,14 @@ class RandomnessMixin:
         :param request_id: The request ID.
         :return: The status of the request.
         """
+        logger.info("GETTING STATUS OF")
+        logger.info(f"{caller_address} - {request_id}")
         (response,) = await self.randomness.functions["get_request_status"].call(
             caller_address,
             request_id,
             block_number=block_id,
         )
+        logger.info(f"response={response} ({response.variant})")
         return RequestStatus(response.variant)
 
     async def get_total_fees(self, caller_address: Address, request_id: int) -> int:
@@ -424,23 +427,28 @@ class RandomnessMixin:
 
         # We either retrieve the [requests_events] provided events or index ourselves
         # the request events.
-        events = requests_events or await self._index_randomness_requests_events(
-            from_block=min_block,
-            to_block="pending",
-        )
-        if not events:
+        if requests_events is None:
+            events = await self._index_randomness_requests_events(
+                from_block=min_block,
+                to_block="pending",
+            )
+        else:
+            events = requests_events
+
+        if not events or len(events) == 0:
             return
 
         # We only keep the RECEIVED requests.
         statuses = await asyncio.gather(
             *(
                 self.get_request_status(
-                    event.caller_address, event.request_id, block_id="pending"
+                    caller_address=event.caller_address,
+                    request_id=event.request_id,
+                    block_id="pending",
                 )
                 for event in events
             )
         )
-        logger.info(f"Found statuses: {statuses}")
         filtered: List[Tuple[RequestStatus, RandomnessRequest]] = [
             (status, event)
             for status, event in zip(statuses, events)

--- a/pragma-sdk/pragma_sdk/onchain/mixins/randomness.py
+++ b/pragma-sdk/pragma_sdk/onchain/mixins/randomness.py
@@ -213,14 +213,11 @@ class RandomnessMixin:
         :param request_id: The request ID.
         :return: The status of the request.
         """
-        logger.info("GETTING STATUS OF")
-        logger.info(f"{caller_address} - {request_id}")
         (response,) = await self.randomness.functions["get_request_status"].call(
             caller_address,
             request_id,
             block_number=block_id,
         )
-        logger.info(f"response={response} ({response.variant})")
         return RequestStatus(response.variant)
 
     async def get_total_fees(self, caller_address: Address, request_id: int) -> int:

--- a/pragma-sdk/pragma_sdk/onchain/mixins/randomness.py
+++ b/pragma-sdk/pragma_sdk/onchain/mixins/randomness.py
@@ -455,7 +455,7 @@ class RandomnessMixin:
             return
 
         statuses, events = zip(*filtered)  # type: ignore[assignment]
-        logger.debug(f"Got {len(events)} RECEIVED events to process")
+        logger.debug(f"Got {len(events)} RECEIVED event(s) to process")
 
         block_hashes = await self.fetch_block_hashes(
             events=events,
@@ -471,7 +471,7 @@ class RandomnessMixin:
 
         invoke_tx = await self.submit_random_multicall(vrf_submit_requests)
         if not invoke_tx:
-            logger.error(f"⛔ VRF Submission for {len(events)} failed!")
+            raise ValueError(f"⛔ VRF Submission for {len(events)} failed!")
         else:
             logger.info(
                 f"✅ Submitted the VRF responses for {len(events)} requests:"

--- a/pragma-sdk/pragma_sdk/onchain/mixins/randomness.py
+++ b/pragma-sdk/pragma_sdk/onchain/mixins/randomness.py
@@ -441,6 +441,7 @@ class RandomnessMixin:
                 for event in events
             )
         )
+        logger.info(f"Found statuses: {statuses}")
         filtered: List[Tuple[RequestStatus, RandomnessRequest]] = [
             (status, event)
             for status, event in zip(statuses, events)

--- a/pragma-sdk/pragma_sdk/onchain/mixins/randomness.py
+++ b/pragma-sdk/pragma_sdk/onchain/mixins/randomness.py
@@ -172,6 +172,10 @@ class RandomnessMixin:
         invocation = await self.account.execute_v1(  # type: ignore[union-attr]
             calls=all_calls, max_fee=self.execution_config.max_fee
         )
+        await self.full_node_client.wait_for_tx(
+            tx_hash=invocation.transaction_hash,
+            check_interval=1,
+        )
         return invocation
 
     async def estimate_gas_submit_random_op(

--- a/vrf-listener/vrf_listener/indexer.py
+++ b/vrf-listener/vrf_listener/indexer.py
@@ -37,6 +37,7 @@ class Indexer:
         pragma_client: PragmaOnChainClient,
         apibara_api_key: Optional[str],
         requests_queue: ThreadSafeQueue,
+        ignore_request_threshold: int,
         from_block: Optional[int] = None,
     ):
         """
@@ -72,7 +73,7 @@ class Indexer:
             filter=filter,
             finality=DataFinality.DATA_STATUS_PENDING,
             batch_size=1,
-            cursor=starknet_cursor(current_block),
+            cursor=starknet_cursor(current_block - ignore_request_threshold),
         )
         return cls(stream=stream, requests_queue=requests_queue)
 

--- a/vrf-listener/vrf_listener/indexer.py
+++ b/vrf-listener/vrf_listener/indexer.py
@@ -81,7 +81,7 @@ class Indexer:
         Index forever using Apibara and fill the requests_queue when encountering a
         VRF request.
         """
-        logger.info("👩‍💻 Indexing VRF requests using apibara...")
+        logger.info("👩‍💻 Self-Indexing VRF requests using Apibara...")
         block = Block()
         async for message in self.stream:
             if message.data is None:

--- a/vrf-listener/vrf_listener/listener.py
+++ b/vrf-listener/vrf_listener/listener.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import traceback
 
 from typing import Optional, List, Set
 
@@ -58,6 +59,7 @@ class Listener:
                 )
             except Exception as e:
                 logger.error(f"⛔ Error while handling randomness request: {e}")
+                logger.error(f"Traceback:\n{''.join(traceback.format_exc())}")
                 self.processed_requests.clear()
             await asyncio.sleep(self.check_requests_interval)
 

--- a/vrf-listener/vrf_listener/listener.py
+++ b/vrf-listener/vrf_listener/listener.py
@@ -59,8 +59,8 @@ class Listener:
                     logger.info(f"🔥 Consumed {len(events)} event(s) from the indexing queue...")
                 if len(self.requests_to_retry) > 0:
                     logger.info(
-                        f"🏥 Found {len(self.requests_to_retry)} event(s) that failed before, "
-                        "adding them to the submission list..."
+                        f"🧑‍⚕ Found {len(self.requests_to_retry)} event(s) that failed before, "
+                        "adding to the requests list..."
                     )
                     events += list(set(list(self.requests_to_retry)))
                     self.requests_to_retry = set()
@@ -75,6 +75,7 @@ class Listener:
                 logger.error(f"Traceback:\n{''.join(traceback.format_exc())}")
                 # If the submission failed, keep track of the failed requests & retry next loop
                 if self.is_indexing:
+                    logger.info("🏥 Saving failed requests for next loop...")
                     self.requests_to_retry.update(events)
             await asyncio.sleep(self.check_requests_interval)
 

--- a/vrf-listener/vrf_listener/listener.py
+++ b/vrf-listener/vrf_listener/listener.py
@@ -50,7 +50,7 @@ class Listener:
             if self.indexer is not None:
                 events = await self._consume_requests_queue()
                 if len(events) > 0:
-                    logger.info(f"🔥 Consumed {len(events)} events from the indexing queue...")
+                    logger.info(f"🔥 Consumed {len(events)} event(s) from the indexing queue...")
             try:
                 await self.pragma_client.handle_random(
                     private_key=self.private_key,
@@ -67,7 +67,7 @@ class Listener:
         """
         Consumes the whole requests_queue and return the requests.
         """
-        events = []
+        events = list()
         while not self.requests_queue.empty():
             try:
                 request: RandomnessRequest = await self.requests_queue.get()

--- a/vrf-listener/vrf_listener/listener.py
+++ b/vrf-listener/vrf_listener/listener.py
@@ -58,6 +58,10 @@ class Listener:
                 if len(events) > 0:
                     logger.info(f"🔥 Consumed {len(events)} event(s) from the indexing queue...")
                 if len(self.requests_to_retry) > 0:
+                    logger.info(
+                        f"🏥 Found {len(self.requests_to_retry)} event(s) that failed before, "
+                        "adding them to the submission list..."
+                    )
                     events += list(set(list(self.requests_to_retry)))
                     self.requests_to_retry = set()
             try:
@@ -69,6 +73,7 @@ class Listener:
             except Exception as e:
                 logger.error(f"⛔ Error while handling randomness request: {e}")
                 logger.error(f"Traceback:\n{''.join(traceback.format_exc())}")
+                # If the submission failed, keep track of the failed requests & retry next loop
                 if self.is_indexing:
                     self.requests_to_retry.update(events)
             await asyncio.sleep(self.check_requests_interval)

--- a/vrf-listener/vrf_listener/listener.py
+++ b/vrf-listener/vrf_listener/listener.py
@@ -48,6 +48,8 @@ class Listener:
         while True:
             if self.indexer is not None:
                 events = await self._consume_requests_queue()
+                if len(events) > 0:
+                    logger.info(f"🔥 Consumed {len(events)} events from the indexing queue...")
             try:
                 await self.pragma_client.handle_random(
                     private_key=self.private_key,

--- a/vrf-listener/vrf_listener/main.py
+++ b/vrf-listener/vrf_listener/main.py
@@ -10,6 +10,7 @@ from pragma_utils.logger import setup_logging
 from pragma_utils.cli import load_private_key_from_cli_arg
 from pragma_sdk.onchain.types import ContractAddresses
 from pragma_sdk.onchain.client import PragmaOnChainClient
+from pragma_sdk.common.logging import get_pragma_sdk_logger
 
 from vrf_listener.safe_queue import ThreadSafeQueue
 from vrf_listener.indexer import Indexer
@@ -181,6 +182,9 @@ def cli_entrypoint(
     VRF Listener entry point.
     """
     setup_logging(logger, log_level)
+    pragma_sdk_logger = get_pragma_sdk_logger()
+    pragma_sdk_logger.setLevel(log_level)
+
     private_key = load_private_key_from_cli_arg(raw_private_key)
 
     if isinstance(private_key, tuple):

--- a/vrf-listener/vrf_listener/main.py
+++ b/vrf-listener/vrf_listener/main.py
@@ -51,6 +51,7 @@ async def main(
             pragma_client=client,
             apibara_api_key=apibara_api_key,
             requests_queue=requests_queue,
+            ignore_request_threshold=ignore_request_threshold,
         )
         asyncio.create_task(indexer.run_forever())
 


### PR DESCRIPTION
#### (PR #200 🥳)
<!-- Reference any GitHub issues resolved by this PR -->

Closes #NA

## Introduced changes

<!-- A brief description of the changes -->

- Added logs to check whats happening
- Retry system for failed VRF submissions
- fix `requests_events` condition check

##

- [ ] This PR contains breaking changes

<!-- List of all breaking changes -->


## Thoughts

All of our issues looks related to sync problems.

Breakdown:
1. We chose Apibara for indexing due to a lag in Starknet.py. There was a noticeable delay between event emission and our ability to retrieve it using the `get_event` function.
2. Upon further investigation, we realized this issue likely stems from our RPC choice rather than Starknet.py itself.
3. We're now dealing with a challenging synchronization scenario. There's an unpredictable gap between when an event is submitted and when it becomes accessible via the Fullnode. This creates various issues, with severity fluctuating based on our chosen RPC.
4. As a temporary solution, we've implemented a retry mechanism to mitigate these synchronization problems.


## Follow-up
* More details on the errors per RPC (Blast, Voyager, our own...)