### PR TITLE
fix: Mandatory VRF request fees estimation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,7 @@
 
 ### Fix
 
-- **stable_but_slow_vrf**: Revert + Tweak old stable vrf
-- **stable_but_slow_vrf**: removed keys
-- **stable_but_slow_vrf**: Todo stuff
-- **stable_but_slow_vrf**: Indexing without apibara
-- **stable_but_slow_vrf**: Fix test
-- **stable_but_slow_vrf**: check interval
-- **estimate_fee_fix**: fix (#196)
-- **merkle_maker**: module name
+- Stable vrf
 - remove useless params (#192)
 - update lock files in ci (#190)
 

--- a/infra/vrf-listener/Dockerfile
+++ b/infra/vrf-listener/Dockerfile
@@ -30,4 +30,4 @@ RUN poetry install
 FROM base as final
 COPY --from=builder /opt /opt
 WORKDIR /opt/vrf-listener
-ENTRYPOINT /opt/vrf-listener/.venv/bin/python3.12 vrf_listener/main.py -n ${NETWORK} --vrf-address ${VRF_ADDRESS} --admin-address ${ADMIN_ADDRESS} --private-key ${PRIVATE_KEY} -t ${CHECK_INTERVAL} --rpc-url ${RPC_URL} --ignore-request-threshold 5
+ENTRYPOINT /opt/vrf-listener/.venv/bin/python3.12 vrf_listener/main.py -n ${NETWORK} --vrf-address ${VRF_ADDRESS} --admin-address ${ADMIN_ADDRESS} --private-key ${PRIVATE_KEY} -t ${CHECK_INTERVAL} --rpc-url ${RPC_URL} --ignore-request-threshold 5 -w ${LOOT_CONTRACT_ADDRESS}

--- a/infra/vrf-listener/config.yml
+++ b/infra/vrf-listener/config.yml
@@ -13,3 +13,4 @@ container_environment:
       - CHECK_INTERVAL
       - RPC_URL
       - APIBARA_API_KEY
+      - LOOT_CONTRACT_ADDRESS

--- a/pragma-sdk/pragma_sdk/onchain/mixins/randomness.py
+++ b/pragma-sdk/pragma_sdk/onchain/mixins/randomness.py
@@ -164,7 +164,7 @@ class RandomnessMixin:
                 "invoking self._setup_account_client(private_key, account_contract_address)"
             )
 
-        ESS = time.time()
+        timer_before_calls = time.time()
         all_calls = await asyncio.gather(
             *[
                 self._get_submit_or_refund_calls(request=request)
@@ -172,7 +172,7 @@ class RandomnessMixin:
             ]
         )
         all_calls = flatten_list(all_calls)
-        print(f"Call creation took: {(time.time()) - ESS:02f}s")
+        logger.info(f"Call creation took: {(time.time()) - timer_before_calls:02f}s")
 
         invocation = await self.randomness.multicall(
             prepared_calls=all_calls,
@@ -477,8 +477,9 @@ class RandomnessMixin:
             sk=felt_to_secret_key(private_key),
         )
 
-        NOW = time.time()
+        timer_send_tx = time.time()
         invoke_tx = await self.submit_random_multicall(vrf_submit_requests)
+        logger.info(f"Send tx took: {(time.time()) - timer_send_tx:02f}s")
         if not invoke_tx:
             logger.error(f"⛔ VRF Submission for {len(events)} failed!")
         else:
@@ -486,7 +487,6 @@ class RandomnessMixin:
                 f"✅ Submitted the VRF responses for {len(events)} requests:"
                 f" {hex(invoke_tx.hash)}"
             )
-        print(f"Send tx took: {(time.time()) - NOW:02f}s")
 
     async def fetch_block_hashes(
         self,

--- a/pragma-sdk/pragma_sdk/onchain/mixins/randomness.py
+++ b/pragma-sdk/pragma_sdk/onchain/mixins/randomness.py
@@ -189,6 +189,10 @@ class RandomnessMixin:
             prepared_calls=all_calls,
             execution_config=self.execution_config,
         )
+        await self.full_node_client.wait_for_tx(
+            tx_hash=invocation.hash,
+            check_interval=0.5,
+        )
         return invocation
 
     async def estimate_gas_submit_random_op(

--- a/pragma-sdk/pragma_sdk/onchain/types/contract.py
+++ b/pragma-sdk/pragma_sdk/onchain/types/contract.py
@@ -1,7 +1,8 @@
 import asyncio
 
-from typing import Awaitable, Callable, Optional, Any, Dict
+from typing import Awaitable, Callable, Optional, Any, Dict, List
 
+from starknet_py.net.account.account import Call
 from starknet_py.contract import Contract as StarknetContract
 from starknet_py.contract import ContractFunction, InvokeResult
 from starknet_py.net.client_models import SentTransactionResponse
@@ -22,6 +23,54 @@ class Contract(StarknetContract):  # type: ignore[misc]
 
 # Global dictionary to store locks for each account
 account_locks: Dict[str, asyncio.Lock] = {}
+
+
+async def _multicall(
+    self: Contract,
+    prepared_calls: List[Call],
+    execution_config: ExecutionConfig = ExecutionConfig(auto_estimate=True),
+    callback: Optional[
+        Callable[[SentTransactionResponse, str], Awaitable[None]]
+    ] = None,
+) -> InvokeResult:
+    """
+    Allows for a callback in the invocation of a contract method.
+    This is useful for tracking the nonce changes
+    """
+    # Get or create a lock for this account
+    account_address = str(self.account.address)
+    if account_address not in account_locks:
+        account_locks[account_address] = asyncio.Lock()
+
+    # We have concurrency issues on the account if we don't do this
+    # because two calls parallel can end up generating the same nonce.
+    # We really want to avoid that.
+    async with account_locks[account_address]:
+        transaction = (
+            await self.account.sign_invoke_v3(
+                calls=prepared_calls,
+                l1_resource_bounds=execution_config.l1_resource_bounds,
+                auto_estimate=execution_config.auto_estimate,
+            )
+            if execution_config.enable_strk_fees
+            else await self.account.sign_invoke_v1(
+                calls=prepared_calls,
+                max_fee=execution_config.max_fee,
+            )
+        )
+
+    response = await self.client.send_transaction(transaction)
+    if callback:
+        await callback(transaction.nonce, response.transaction_hash)
+
+    invoke_result = InvokeResult(
+        hash=response.transaction_hash,
+        _client=self.client,
+        contract=self,
+        invoke_transaction=transaction,
+    )
+
+    return invoke_result
 
 
 async def _invoke(
@@ -85,5 +134,8 @@ async def _invoke(
     return invoke_result
 
 
-# patch contract function to use new invoke function
+# patch [Contract] with new call
+Contract.multicall = _multicall
+
+# patch [ContractFunction] to use new invoke function
 ContractFunction.invoke = _invoke

--- a/pragma-sdk/tests/integration/vrf_test.py
+++ b/pragma-sdk/tests/integration/vrf_test.py
@@ -344,7 +344,7 @@ async def test_fails_gas_limit(
     assert pending_reqs == []
 
     status = await vrf_pragma_client.get_request_status(caller_address, 3)
-    assert (status == RequestStatus.REFUNDED)
+    assert status == RequestStatus.REFUNDED
 
     balance_after = await vrf_pragma_client.get_balance(caller_address)
 

--- a/pragma-sdk/tests/integration/vrf_test.py
+++ b/pragma-sdk/tests/integration/vrf_test.py
@@ -344,9 +344,7 @@ async def test_fails_gas_limit(
     assert pending_reqs == []
 
     status = await vrf_pragma_client.get_request_status(caller_address, 3)
-    assert (
-        status == RequestStatus.FULFILLED
-    )  # TODO(akhercha): investigate, should be REFUNDED?
+    assert (status == RequestStatus.REFUNDED)
 
     balance_after = await vrf_pragma_client.get_balance(caller_address)
 

--- a/vrf-listener/README.md
+++ b/vrf-listener/README.md
@@ -11,37 +11,50 @@ The service is ran through the CLI, to have more information you can use the `--
 
 Usage: main.py [OPTIONS]
 
+    VRF Listener entry point.
+
 Options:
   --log-level [DEBUG|INFO|WARNING|ERROR|CRITICAL]
                                   Logging level.
-
-  -n, --network [sepolia|mainnet|devnet]
+                                  
+  -n, --network [sepolia|mainnet]
                                   Which network to listen. Defaults to
                                   SEPOLIA.  [required]
-
+                                  
   --rpc-url TEXT                  RPC url used by the onchain client.
-
+                                  
   --vrf-address TEXT              Address of the VRF contract  [required]
-
+                                  
   --admin-address TEXT            Address of the Admin contract  [required]
-
-  -p, --private-key TEXT          Secret key of the signer. Format:
-                                  aws:secret_name, plain:secret_key, or
+                                  
+  -p, --private-key TEXT          Private key of the signer. Format:
+                                  aws:secret_name, plain:private_key, or
                                   env:ENV_VAR_NAME  [required]
-
-  -b--start-block INTEGER RANGE   At which block to start listening for VRF
-                                  requests. Defaults to 0.  [x>=0]
-
-  -t, --check-requests-interval   Delay in seconds between checks for VRF
+                                  
+  -t, --check-requests-interval INTEGER RANGE
+                                  Delay in seconds between checks for VRF
                                   requests. Defaults to 10 seconds.  [x>=0]
+                                  
+  --ignore-request-threshold INTEGER RANGE
+                                  Blocks to ignore before the current block
+                                  for the handling.  [x>=0]
+                                  
+  --index-with-apibara            Self index the VRF requests using Apibara
+                                  instead of using Starknet.py
+                                  
+  --apibara-api-key TEXT          Apibara API key. Needed when indexing with
+                                  Apibara.
 
+  -w, --whitelisted HEX_STRING    List of whitelisted addresses for which we
+                                  won't check their fees and pay for them if
+                                  needed.
   --help                          Show this message and exit.
 ```
 
 For example:
 
 ```sh
-poetry run vrf_listener --vrf-address $PRAGMA_VRF_CONTRACT --admin-address $PRAGMA_ORACLE_ADMIN --private-key plain:$PRAGMA_ADMIN_PV_KEY
+poetry run vrf_listener --vrf-address $PRAGMA_VRF_CONTRACT --admin-address $PRAGMA_ORACLE_ADMIN --private-key plain:$PRAGMA_ADMIN_PV_KEY -w $ADDR_1 -w $ADDR_2 # ...
 ```
 
 Will start listening for VRF requests on Sepolia every 10 seconds since block 0.

--- a/vrf-listener/benchmark/devnet/contracts.py
+++ b/vrf-listener/benchmark/devnet/contracts.py
@@ -16,7 +16,7 @@ def find_repo_root(start_directory: Path) -> Path:
 
 
 CURRENT_FILE_DIRECTORY = Path(__file__).parent
-REPO_ROOT = find_repo_root(CURRENT_FILE_DIRECTORY).parent.parent
+REPO_ROOT = find_repo_root(CURRENT_FILE_DIRECTORY).parent
 SUBMODULE_DIR = REPO_ROOT / "pragma-oracle"
 CONTRACTS_COMPILED_DIR = SUBMODULE_DIR / "target/dev"
 

--- a/vrf-listener/benchmark/stress/stress_tester.py
+++ b/vrf-listener/benchmark/stress/stress_tester.py
@@ -46,7 +46,7 @@ class StressTester:
         self.oracle_address = int(oracle_address, 16) if oracle_address else None
 
     async def run_stresstest(self) -> None:
-        full_node = FullNodeClient(node_url=self.rpc_url)
+        full_node = FullNodeClient(node_url="https://api.cartridge.gg/x/starknet/sepolia")
 
         # 1. Deploy vrf etc etc
         print("\n🧩 Deploying VRF contracts...")
@@ -68,7 +68,7 @@ class StressTester:
         print("\n🧩 Creating user clients...")
         users = await self.config.get_users_client(
             network=self.network,
-            rpc_url=self.rpc_url,
+            rpc_url="https://api.cartridge.gg/x/starknet/sepolia",
             randomness_contracts=randomness_contracts,
         )
         print("✅ done!")
@@ -189,7 +189,7 @@ class StressTester:
                 admin_address=admin_address,
                 private_key=private_key,
                 check_requests_interval=1,
-                ignore_request_threshold=5,
+                ignore_request_threshold=10,
             )
         )
         return vrf_listener_task

--- a/vrf-listener/benchmark/stress/stress_tester.py
+++ b/vrf-listener/benchmark/stress/stress_tester.py
@@ -46,7 +46,7 @@ class StressTester:
         self.oracle_address = int(oracle_address, 16) if oracle_address else None
 
     async def run_stresstest(self) -> None:
-        full_node = FullNodeClient(node_url="https://api.cartridge.gg/x/starknet/sepolia")
+        full_node = FullNodeClient(node_url=self.rpc_url)
 
         # 1. Deploy vrf etc etc
         print("\n🧩 Deploying VRF contracts...")
@@ -68,7 +68,7 @@ class StressTester:
         print("\n🧩 Creating user clients...")
         users = await self.config.get_users_client(
             network=self.network,
-            rpc_url="https://api.cartridge.gg/x/starknet/sepolia",
+            rpc_url=self.rpc_url,
             randomness_contracts=randomness_contracts,
         )
         print("✅ done!")

--- a/vrf-listener/vrf_listener/click_types.py
+++ b/vrf-listener/vrf_listener/click_types.py
@@ -1,0 +1,28 @@
+import click
+
+from typing import List, Set
+
+from pragma_sdk.common.types.types import Address
+
+
+def validate_hex_string(value: str) -> str:
+    if not value.startswith("0x") or not all(c in "0123456789ABCDEFabcdef" for c in value[2:]):
+        raise ValueError(f"Invalid hexadecimal string: {value}")
+    return value
+
+
+class HexStringCliArg(click.ParamType):
+    name = "hex_string"
+
+    def convert(self, value, param, ctx):
+        try:
+            return validate_hex_string(value)
+        except ValueError:
+            self.fail(f"{value!r} is not a valid hexadecimal string", param, ctx)
+
+
+HEX_STRING = HexStringCliArg()
+
+
+def hex_addresses_list_to_addresses_set(addresses: List[str]) -> Set[Address]:
+    return set([int(addr, 16) for addr in addresses])

--- a/vrf-listener/vrf_listener/click_types.py
+++ b/vrf-listener/vrf_listener/click_types.py
@@ -6,7 +6,9 @@ from pragma_sdk.common.types.types import Address
 
 
 def validate_hex_string(value: str) -> str:
-    if not value.startswith("0x") or not all(c in "0123456789ABCDEFabcdef" for c in value[2:]):
+    if not value.startswith("0x") or not all(
+        c in "0123456789ABCDEFabcdef" for c in value[2:].lower()
+    ):
         raise ValueError(f"Invalid hexadecimal string: {value}")
     return value
 

--- a/vrf-listener/vrf_listener/listener.py
+++ b/vrf-listener/vrf_listener/listener.py
@@ -5,6 +5,7 @@ from typing import Optional, List, Set
 
 
 from pragma_sdk.onchain.types import RandomnessRequest
+from pragma_sdk.common.types.types import Address
 from pragma_sdk.onchain.client import PragmaOnChainClient
 
 from vrf_listener.indexer import Indexer
@@ -18,6 +19,7 @@ class Listener:
     private_key: int
     requests_queue: ThreadSafeQueue
     check_requests_interval: int
+    whitelisted_addresses: Set[Address]
     processed_requests: Set[RandomnessRequest]
     indexer: Optional[Indexer] = None
 
@@ -28,6 +30,7 @@ class Listener:
         requests_queue: ThreadSafeQueue,
         check_requests_interval: int,
         ignore_request_threshold: int,
+        whitelisted_addresses: Set[Address],
         indexer: Optional[Indexer] = None,
     ) -> None:
         self.pragma_client = pragma_client
@@ -37,6 +40,7 @@ class Listener:
         self.requests_queue = requests_queue
         self.check_requests_interval = check_requests_interval
         self.ignore_request_threshold = ignore_request_threshold
+        self.whitelisted_addresses = whitelisted_addresses
         self.processed_requests = set()
         self.indexer = indexer
 
@@ -53,6 +57,7 @@ class Listener:
                     private_key=self.private_key,
                     ignore_request_threshold=self.ignore_request_threshold,
                     requests_events=events if self.indexer is not None else None,
+                    whitelisted_addresses=self.whitelisted_addresses,
                 )
             except Exception as e:
                 logger.error(f"⛔ Error while handling randomness request: {e}")


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #NA

## Introduced changes

<!-- A brief description of the changes -->
- Re-added mandatory fee check
- Multicall impl (without wait_for_tx)
- whitelist for which we don't check fees

Note: Adding `track_nonce` adds way to much unreliability. Better to loose a few seconds waiting for the tx than pilling up txs that will fail and retry requests.

##

- [ ] This PR contains breaking changes

<!-- List of all breaking changes -->
