### PR TITLE
fix: Ekubo fetcher for quote_address == 0

### DIFF
--- a/pragma-sdk/pragma_sdk/common/fetchers/fetchers/ekubo.py
+++ b/pragma-sdk/pragma_sdk/common/fetchers/fetchers/ekubo.py
@@ -109,7 +109,7 @@ class EkuboFetcher(FetcherInterfaceT):
         """
         return [
             PublisherFetchError(
-                f"No data found for {Pair(quote[0], base)} from Ekubo:"
+                f"No data found for {Pair(base, quote[0])} from Ekubo:"
                 f' no onchain starknet address for "{quote[0].id}"'
             )
             for base in base_currencies


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #NA

## Introduced changes

<!-- A brief description of the changes -->

- The Ekubo fetcher does not raise errors when the quote currency address is zero. We added a check. (EUR is an abstract currency, hence starknet_address == 0, was returning 1 from the contract)

##

- [ ] This PR contains breaking changes

<!-- List of all breaking changes -->
