### PR TITLE
hotfix: Dexscreener fetcher

### DIFF
--- a/pragma-sdk/pragma_sdk/common/fetchers/fetchers/dexscreener.py
+++ b/pragma-sdk/pragma_sdk/common/fetchers/fetchers/dexscreener.py
@@ -103,7 +103,10 @@ class DexscreenerFetcher(FetcherInterfaceT):
         """
         Format the URL to fetch in order to retrieve the price for a pair.
         """
-        base_address = f"{pair.base_currency.starknet_address:#0{66}x}"
+        if pair.base_currency.starknet_address is not None:
+            base_address = f"{pair.base_currency.starknet_address:#0{66}x}"
+        else:
+            base_address = f"{pair.base_currency.ethereum_address:#0{66}x}"
         return f"{self.BASE_URL}/{base_address}"
 
     def _construct(self, pair: Pair, result: float, volume: float) -> SpotEntry:

--- a/pragma-sdk/pragma_sdk/common/fetchers/fetchers/dexscreener.py
+++ b/pragma-sdk/pragma_sdk/common/fetchers/fetchers/dexscreener.py
@@ -106,7 +106,7 @@ class DexscreenerFetcher(FetcherInterfaceT):
         if pair.base_currency.starknet_address is not None:
             base_address = f"{pair.base_currency.starknet_address:#0{66}x}"
         else:
-            base_address = f"{pair.base_currency.ethereum_address:#0{66}x}"
+            base_address = f"{pair.base_currency.ethereum_address:#0{42}x}"
         return f"{self.BASE_URL}/{base_address}"
 
     def _construct(self, pair: Pair, result: float, volume: float) -> SpotEntry:

--- a/pragma-sdk/pragma_sdk/common/fetchers/fetchers/dexscreener.py
+++ b/pragma-sdk/pragma_sdk/common/fetchers/fetchers/dexscreener.py
@@ -4,10 +4,8 @@ import time
 from typing import List
 from aiohttp import ClientSession
 
-from pragma_sdk.common.fetchers.handlers.hop_handler import HopHandler
 from pragma_sdk.common.types.entry import Entry, SpotEntry
 from pragma_sdk.common.types.pair import Pair
-from pragma_sdk.common.types.currency import Currency
 from pragma_sdk.common.exceptions import PublisherFetchError
 from pragma_sdk.common.fetchers.interface import FetcherInterfaceT
 from pragma_sdk.common.logging import get_pragma_sdk_logger
@@ -19,27 +17,21 @@ logger = get_pragma_sdk_logger()
 class DexscreenerFetcher(FetcherInterfaceT):
     """
     Dexscreener fetcher.
-    NOTE: Only works for Starknet at the moment.
+    NOTE: Only supports USD for quote currencies for now.
 
-    Also, the API is still in beta so we expect breaking changes to happen.
+    ⚠⚠ The API is still in beta so we expect breaking changes to happen.
+    We will support other quote assets when the API is stable.
     """
 
     publisher: str
     pairs: List[Pair]
 
-    hop_handler = HopHandler(
-        hopped_currencies={
-            "USD": "USDC",
-        }
-    )
     SOURCE = "DEXSCREENER"
-    BASE_URL: str = "https://api.dexscreener.com/latest/dex"
-
-    # NOTE: We only check for starknet for now
-    CHAIN_ID = "starknet"
+    BASE_URL: str = "https://api.dexscreener.com/latest/dex/tokens"
 
     async def fetch(
-        self, session: ClientSession
+        self,
+        session: ClientSession,
     ) -> List[Entry | PublisherFetchError | BaseException]:
         """
         Fetch prices from all pairs from Dexscreener.
@@ -57,17 +49,8 @@ class DexscreenerFetcher(FetcherInterfaceT):
 
         NOTE: The currencies of the pair must have a starknet_address.
         """
-        hopped_pair = self.hop_handler.get_hop_pair(pair) or pair
-        if hopped_pair.base_currency.starknet_address == 0:
-            return PublisherFetchError(
-                f"Failed to fetch data for {hopped_pair} from Dexscreener: "
-                f"{hopped_pair.base_currency.id} starknet_address is None."
-            )
-        if hopped_pair.base_currency.starknet_address == 0:
-            return PublisherFetchError(
-                f"Failed to fetch data for {hopped_pair} from Dexscreener: "
-                f"{hopped_pair.quote_currency.id} starknet_address is None."
-            )
+        if pair.quote_currency.id != "USD":
+            return PublisherFetchError(f"No data found for {pair} from Dexscreener")
         return await self._fetch_dexscreener_price(pair, session)
 
     async def _fetch_dexscreener_price(
@@ -82,21 +65,12 @@ class DexscreenerFetcher(FetcherInterfaceT):
         sometimes the quote asset is in front of the base asset...
         To be sure it works, we try both.
         """
-        hopped_pair = self.hop_handler.get_hop_pair(pair) or pair
         pair_data = await self._query_dexscreener(
-            hopped_pair.base_currency,
-            hopped_pair.quote_currency,
+            pair,
             session,
         )
-
         if isinstance(pair_data, PublisherFetchError):
-            pair_data = await self._query_dexscreener(
-                hopped_pair.quote_currency,
-                hopped_pair.base_currency,
-                session,
-            )
-            if isinstance(pair_data, PublisherFetchError):
-                return PublisherFetchError(f"No data found for {pair} from Dexscreener")
+            return PublisherFetchError(f"No data found for {pair} from Dexscreener")
 
         return self._construct(
             pair=pair,
@@ -105,21 +79,22 @@ class DexscreenerFetcher(FetcherInterfaceT):
         )
 
     async def _query_dexscreener(
-        self, base: Currency, quote: Currency, session: ClientSession
+        self,
+        pair: Pair,
+        session: ClientSession,
     ) -> dict | PublisherFetchError:
-        pair_id = f"{base.id}/{quote.id}"
-        url = self.format_url(Pair.from_tickers(base.id, quote.id))
+        url = self.format_url(pair)
         async with session.get(url) as resp:
             if resp.status == 404:
                 return PublisherFetchError(
-                    f"No data found for {pair_id} from Dexscreener"
+                    f"No data found for {pair.id} from Dexscreener"
                 )
             if resp.status == 200:
                 response = await resp.json()
                 # NOTE: Response are sorted by highest liq, so we take the first.
-                if len(response["pairs"]) > 0:
+                if response["pairs"] is not None and len(response["pairs"]) > 0:
                     return response["pairs"][0]  # type: ignore[no-any-return]
-        return PublisherFetchError(f"No data found for {pair_id} from Dexscreener")
+        return PublisherFetchError(f"No data found for {pair.id} from Dexscreener")
 
     def format_url(  # type: ignore[override]
         self,
@@ -129,8 +104,7 @@ class DexscreenerFetcher(FetcherInterfaceT):
         Format the URL to fetch in order to retrieve the price for a pair.
         """
         base_address = f"{pair.base_currency.starknet_address:#0{66}x}"
-        quote_address = f"{pair.quote_currency.starknet_address:#0{66}x}"
-        return f"{self.BASE_URL}/search?q={base_address}-{quote_address}"
+        return f"{self.BASE_URL}/{base_address}"
 
     def _construct(self, pair: Pair, result: float, volume: float) -> SpotEntry:
         price_int = int(result * (10 ** pair.decimals()))

--- a/pragma-sdk/pragma_sdk/common/fetchers/fetchers/dexscreener.py
+++ b/pragma-sdk/pragma_sdk/common/fetchers/fetchers/dexscreener.py
@@ -47,7 +47,8 @@ class DexscreenerFetcher(FetcherInterfaceT):
         """
         Fetch the price for a pair and return the SpotEntry.
 
-        NOTE: The currencies of the pair must have a starknet_address.
+        NOTE: The base currency being priced must have either a starknet_address
+        or an ethereum_address.
         """
         if pair.quote_currency.id != "USD":
             return PublisherFetchError(f"No data found for {pair} from Dexscreener")
@@ -110,10 +111,10 @@ class DexscreenerFetcher(FetcherInterfaceT):
         """
         Format the URL to fetch in order to retrieve the price for a pair.
         """
-        if pair.base_currency.starknet_address is not None:
-            base_address = f"{pair.base_currency.starknet_address:#0{66}x}"
-        else:
+        if pair.base_currency.ethereum_address is not None:
             base_address = f"{pair.base_currency.ethereum_address:#0{42}x}"
+        else:
+            base_address = f"{pair.base_currency.starknet_address:#0{66}x}"
         return f"{self.BASE_URL}/{base_address}"
 
     def _construct(self, pair: Pair, result: float, volume: float) -> SpotEntry:

--- a/pragma-sdk/pragma_sdk/common/fetchers/fetchers/dexscreener.py
+++ b/pragma-sdk/pragma_sdk/common/fetchers/fetchers/dexscreener.py
@@ -51,6 +51,13 @@ class DexscreenerFetcher(FetcherInterfaceT):
         """
         if pair.quote_currency.id != "USD":
             return PublisherFetchError(f"No data found for {pair} from Dexscreener")
+        if (pair.base_currency.ethereum_address == 0) and (
+            pair.base_currency.starknet_address == 0
+        ):
+            return PublisherFetchError(
+                f"No on-chain address for {pair.base_currency.id}, "
+                "can't fetch from Dexscreener"
+            )
         return await self._fetch_dexscreener_price(pair, session)
 
     async def _fetch_dexscreener_price(

--- a/pragma-sdk/pragma_sdk/onchain/constants.py
+++ b/pragma-sdk/pragma_sdk/onchain/constants.py
@@ -22,13 +22,11 @@ STARKSCAN_URLS: Dict[Network, str] = {
 RPC_URLS: Dict[Network, List[str]] = {
     "mainnet": [
         "https://starknet-mainnet.public.blastapi.io/rpc/v0_7",
-        "https://rpc.starknet.lava.build:443",
         "https://free-rpc.nethermind.io/mainnet-juno",
         "https://api.cartridge.gg/x/starknet/mainnet",
     ],
     "sepolia": [
         "https://starknet-sepolia.public.blastapi.io/rpc/v0_7",
-        "https://rpc.starknet-testnet.lava.build:443",
         "https://free-rpc.nethermind.io/sepolia-juno",
         "https://api.cartridge.gg/x/starknet/sepolia",
     ],

--- a/pragma-sdk/tests/integration/update_client_test.py
+++ b/pragma-sdk/tests/integration/update_client_test.py
@@ -2,6 +2,7 @@ from typing import List
 
 import pytest
 import pytest_asyncio
+from unittest.mock import MagicMock
 from starknet_py.contract import Contract, DeclareResult
 from starknet_py.net.client_errors import ClientError
 
@@ -55,7 +56,8 @@ async def declare_oracle(forked_client: PragmaOnChainClient) -> DeclareResult:
 
     except ClientError as err:
         if "is already declared" in err.message:
-            logger.info("Contract already declared with this class hash")
+            hash_str = err.message.split("0x")[1].split()[0]
+            return MagicMock(class_hash=int(f"0x{hash_str}", 16))
         else:
             logger.info("An error occured during the declaration: %s", err)
             raise err


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #NA

## Introduced changes

<!-- A brief description of the changes -->

`Dexscreener` fetcher was buggy (or the API changed, as they mentionned it is unstable) and was returning really low liquidity pairs. Hence price was wrong.

To fix that, we adjusted the endpoint and we are now only supporting USD quote assets - until the API is stable and we can choose something else for other quote assets.
Since 90% of our assets are quoted in USD, this is fine.

##

- [ ] This PR contains breaking changes

<!-- List of all breaking changes -->
