### PR TITLE
fix: price pusher circular deps

### DIFF
--- a/price-pusher/price_pusher/core/listener.py
+++ b/price-pusher/price_pusher/core/listener.py
@@ -14,7 +14,7 @@ from pragma_sdk.common.types.types import DataTypes
 from price_pusher.utils import exclude_none_and_exceptions, flatten_list
 from price_pusher.configs import PriceConfig
 from price_pusher.core.request_handlers.interface import IRequestHandler
-from price_pusher.types import (
+from price_pusher.price_types import (
     DurationInSeconds,
     LatestOraclePairPrices,
     LatestOrchestratorPairPrices,

--- a/price-pusher/price_pusher/core/request_handlers/__init__.py
+++ b/price-pusher/price_pusher/core/request_handlers/__init__.py
@@ -1,6 +1,6 @@
 from typing import Dict
 
-from price_pusher.types import Target
+from price_pusher.price_types import Target
 
 from .api import APIRequestHandler
 from .chain import ChainRequestHandler

--- a/price-pusher/price_pusher/main.py
+++ b/price-pusher/price_pusher/main.py
@@ -26,7 +26,7 @@ from price_pusher.configs.price_config import (
     PriceConfig,
 )
 from price_pusher.orchestrator import Orchestrator
-from price_pusher.types import Target, Network
+from price_pusher.price_types import Target, Network
 
 logger = logging.getLogger(__name__)
 

--- a/price-pusher/price_pusher/orchestrator.py
+++ b/price-pusher/price_pusher/orchestrator.py
@@ -10,7 +10,7 @@ from pragma_sdk.common.types.pair import Pair
 from price_pusher.core.poller import PricePoller
 from price_pusher.core.listener import PriceListener
 from price_pusher.core.pusher import PricePusher
-from price_pusher.types import LatestOrchestratorPairPrices
+from price_pusher.price_types import LatestOrchestratorPairPrices
 
 logger = logging.getLogger(__name__)
 

--- a/price-pusher/price_pusher/price_types.py
+++ b/price-pusher/price_pusher/price_types.py
@@ -15,4 +15,4 @@ LatestOrchestratorPairPrices = Dict[
 ]
 LatestOraclePairPrices = Dict[PairId, Dict[DataTypes, Entry]]
 Target = Literal["onchain", "offchain"]
-Network = Literal["mainnet", "sepolia", "pragma_devnet"]
+Network = Literal["mainnet", "sepolia", "pragma_devnet"] 

--- a/price-pusher/price_pusher/utils.py
+++ b/price-pusher/price_pusher/utils.py
@@ -1,9 +1,10 @@
-from typing import List, Union, Optional
+from typing import List, Union, Optional, TypeVar
 
 from pragma_sdk.offchain.client import PragmaAPIError
 
+T = TypeVar('T')
 
-def exclude_none_and_exceptions[T](
+def exclude_none_and_exceptions(
     to_filter: List[Optional[Union[T, BaseException, Exception, PragmaAPIError]]],
 ) -> List[T]:
     """
@@ -13,7 +14,7 @@ def exclude_none_and_exceptions[T](
     return [item for item in to_filter if not isinstance(item, exception_types)]
 
 
-def flatten_list[T](to_flatten: List[Union[T, List[T]]]) -> List[T]:
+def flatten_list(to_flatten: List[Union[T, List[T]]]) -> List[T]:
     """
     Flatten a list that contains items and list of items into a list of items.
     """


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #N/A

## Introduced changes

<!-- A brief description of the changes -->

- Fix circular dependency due to the use of `types.py` filename
- Update typing to support python 3.11.8

##

- [ ] This PR contains breaking changes

<!-- List of all breaking changes -->
