### PR TITLE
feat: websocket publishing w/ auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,16 @@ Our services used to publish data etc...:
 
 ## Local Development
 
+### Resyncing
+
 When developing locally and making changes to the main `pragma-sdk` package make sure to apply your changes by running `uv sync --reinstall`.
+
+### Linters
+
+1. Install `pre-commit` with `pip install pre-commit`
+2. `git add` the files you want to fix lint
+3. `pre-commit run --all-files`
+4. `git add` them again
 
 ## Releasing a new version
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ Our services used to publish data etc...:
 - <a href="./checkpointer">Checkpointer</a>
 - <a href="./merkle-maker">Merkle Maker</a>
 
+## Local Development
+
+When developing locally and making changes to the main `pragma-sdk` package make sure to apply your changes by running `uv sync --reinstall`.
+
 ## Releasing a new version
 
 We provide a version management script to help maintain consistent versioning across all packages.

--- a/pragma-sdk/pragma_sdk/common/fetchers/fetchers/pyth.py
+++ b/pragma-sdk/pragma_sdk/common/fetchers/fetchers/pyth.py
@@ -124,7 +124,7 @@ class PythFetcher(FetcherInterfaceT):
         conf = int(price_data["conf"]) / (10 ** abs(price_data["expo"]))
         timestamp = int(price_data["publish_time"])
         price_int = int(price * (10 ** pair.decimals()))
-        
+
         logger.debug("Fetched price %d (±%f) for %s from Pyth", price_int, conf, pair)
 
         return SpotEntry(

--- a/pragma-sdk/pragma_sdk/common/types/client.py
+++ b/pragma-sdk/pragma_sdk/common/types/client.py
@@ -12,7 +12,7 @@ from pragma_sdk.onchain.types import PublishEntriesOnChainResult
 class PragmaClient(ABC):
     @abstractmethod
     async def publish_entries(
-        self, entries: List[Entry]
+        self, entries: List[Entry], publish_to_websocket: bool = False
     ) -> Union[PublishEntriesAPIResult, PublishEntriesOnChainResult]:
         """
         Publish entries to some destination.

--- a/pragma-sdk/pragma_sdk/offchain/constants.py
+++ b/pragma-sdk/pragma_sdk/offchain/constants.py
@@ -5,3 +5,5 @@ PRAGMA_API_URLS: Dict[Environment, str] = {
     Environment.DEV: "https://api.dev.pragma.build",
     Environment.PROD: "https://api.prod.pragma.build",
 }
+
+WEBSOCKET_TIME_TO_EXPIRE = 60 * 60  # 1 hour

--- a/pragma-sdk/pyproject.toml
+++ b/pragma-sdk/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "python-dotenv>=1.0.0",
     "pyyaml>=6.0.1",
     "redis[hiredis]>=5.0.7",
+    "websockets>=14.0",
 ]
 
 dynamic = ["version"]

--- a/price-pusher/price_pusher/core/pusher.py
+++ b/price-pusher/price_pusher/core/pusher.py
@@ -65,7 +65,9 @@ class PricePusher(IPricePusher):
                     await self.wait_for_publishing_acceptance(response)
             else:
                 start_t = time.time()
-                response = await self.client.publish_entries(entries)
+                response = await self.client.publish_entries(
+                    entries, publish_to_websocket=True
+                )
 
             end_t = time.time()
             logger.info(

--- a/price-pusher/price_pusher/main.py
+++ b/price-pusher/price_pusher/main.py
@@ -41,6 +41,7 @@ async def main(
     poller_refresh_interval: int,
     rpc_url: Optional[str] = None,
     api_base_url: Optional[str] = None,
+    websocket_url: Optional[str] = None,
     api_key: Optional[str] = None,
     max_fee: Optional[int] = None,
     pagination: Optional[int] = None,
@@ -58,6 +59,7 @@ async def main(
         private_key=private_key,
         rpc_url=rpc_url,
         api_base_url=api_base_url,
+        websocket_url=websocket_url,
         api_key=api_key,
         max_fee=max_fee,
         pagination=pagination,
@@ -112,6 +114,7 @@ def _create_client(
     private_key: PrivateKey,
     rpc_url: Optional[str] = None,
     api_base_url: Optional[str] = None,
+    websocket_url: Optional[str] = None,
     api_key: Optional[str] = None,
     max_fee: Optional[int] = None,
     pagination: Optional[int] = None,
@@ -163,6 +166,7 @@ def _create_client(
             account_private_key=private_key,
             api_key=api_key,
             api_base_url=api_base_url,
+            websocket_url=websocket_url,
         )
     else:
         raise ValueError(f"Invalid target: {target}")
@@ -234,6 +238,12 @@ def _create_client(
     "--api-base-url", type=click.STRING, required=False, help="Pragma API base URL"
 )
 @click.option(
+    "--websocket-url",
+    type=click.STRING,
+    required=False,
+    help="Pragma WebSocket URL used to publish offchain",
+)
+@click.option(
     "--api-key",
     type=click.STRING,
     required=False,
@@ -274,6 +284,7 @@ def cli_entrypoint(
     publisher_name: str,
     publisher_address: str,
     api_base_url: Optional[str],
+    websocket_url: Optional[str],
     api_key: Optional[str],
     max_fee: Optional[int],
     pagination: Optional[int],
@@ -329,6 +340,7 @@ def cli_entrypoint(
             publisher_name=publisher_name.upper(),
             publisher_address=publisher_address,
             api_base_url=api_base_url,
+            websocket_url=websocket_url,
             api_key=api_key,
             rpc_url=rpc_url,
             max_fee=max_fee,

--- a/price-pusher/price_pusher/main.py
+++ b/price-pusher/price_pusher/main.py
@@ -312,8 +312,11 @@ def cli_entrypoint(
             logger.warning(
                 '🤔 "enable_strk_fees" option has no use when the target is "offchain". Ignoring it.'
             )
-
-    if target == "onchain":
+    else:  # target == "onchain"
+        if websocket_url:
+            logger.warning(
+                '🤔 "websocket-url" option has no use when the target is "onchain". Ignoring it.'
+            )
         if rpc_url and not rpc_url.startswith("http"):
             raise click.UsageError(
                 '⛔ "rpc_url" format is incorrect. It must start with http(...)'

--- a/price-pusher/tests/unit/core/test_pusher.py
+++ b/price-pusher/tests/unit/core/test_pusher.py
@@ -33,7 +33,9 @@ async def test_update_price_feeds_success(caplog):
     response = await price_pusher.update_price_feeds(entries)
 
     assert response == mock_response
-    mock_client.publish_entries.assert_called_once_with(entries)
+    mock_client.publish_entries.assert_called_once_with(
+        entries, publish_to_websocket=True
+    )
 
     assert any(
         f"processing {len(entries)} new asset(s) to push..." in record.message
@@ -58,7 +60,9 @@ async def test_update_price_feeds_failure(price_pusher, mock_client, caplog):
     response = await price_pusher.update_price_feeds(entries)
 
     assert response is None
-    mock_client.publish_entries.assert_called_once_with(entries)
+    mock_client.publish_entries.assert_called_once_with(
+        entries, publish_to_websocket=True
+    )
 
     assert any(
         "processing 1 new asset(s) to push..." in record.message

--- a/price-pusher/uv.lock
+++ b/price-pusher/uv.lock
@@ -875,7 +875,7 @@ wheels = [
 
 [[package]]
 name = "pragma-sdk"
-version = "2.3.0"
+version = "2.4.12"
 source = { directory = "../pragma-sdk" }
 dependencies = [
     { name = "aioresponses" },
@@ -887,6 +887,7 @@ dependencies = [
     { name = "requests-mock" },
     { name = "starknet-py" },
     { name = "typer" },
+    { name = "websockets" },
 ]
 
 [package.metadata]
@@ -921,11 +922,12 @@ requires-dist = [
     { name = "types-deprecated", marker = "extra == 'typing'", specifier = ">=1.2.9" },
     { name = "types-pyyaml", marker = "extra == 'typing'", specifier = ">=6.0.12.20240311" },
     { name = "types-requests", marker = "extra == 'typing'", specifier = ">=2.26.0" },
+    { name = "websockets", specifier = ">=14.0" },
 ]
 
 [[package]]
 name = "pragma-utils"
-version = "2.3.0"
+version = "2.4.12"
 source = { directory = "../pragma-utils" }
 dependencies = [
     { name = "boto3" },
@@ -956,7 +958,7 @@ requires-dist = [
 
 [[package]]
 name = "price-pusher"
-version = "2.3.0"
+version = "2.4.12"
 source = { editable = "." }
 dependencies = [
     { name = "asgiref" },
@@ -1378,6 +1380,48 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/aa/63/e53da845320b757bf29ef6a9062f5c669fe997973f966045cb019c3f4b66/urllib3-2.3.0.tar.gz", hash = "sha256:f8c5449b3cf0861679ce7e0503c7b44b5ec981bec0d1d3795a07f1ba96f0204d", size = 307268 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/19/4ec628951a74043532ca2cf5d97b7b14863931476d117c471e8e2b1eb39f/urllib3-2.3.0-py3-none-any.whl", hash = "sha256:1cee9ad369867bfdbbb48b7dd50374c0967a0bb7710050facf0dd6911440e3df", size = 128369 },
+]
+
+[[package]]
+name = "websockets"
+version = "14.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/54/8359678c726243d19fae38ca14a334e740782336c9f19700858c4eb64a1e/websockets-14.2.tar.gz", hash = "sha256:5059ed9c54945efb321f097084b4c7e52c246f2c869815876a69d1efc4ad6eb5", size = 164394 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/15/b6/504695fb9a33df0ca56d157f5985660b5fc5b4bf8c78f121578d2d653392/websockets-14.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:3bdc8c692c866ce5fefcaf07d2b55c91d6922ac397e031ef9b774e5b9ea42166", size = 163088 },
+    { url = "https://files.pythonhosted.org/packages/81/26/ebfb8f6abe963c795122439c6433c4ae1e061aaedfc7eff32d09394afbae/websockets-14.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:c93215fac5dadc63e51bcc6dceca72e72267c11def401d6668622b47675b097f", size = 160745 },
+    { url = "https://files.pythonhosted.org/packages/a1/c6/1435ad6f6dcbff80bb95e8986704c3174da8866ddb751184046f5c139ef6/websockets-14.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1c9b6535c0e2cf8a6bf938064fb754aaceb1e6a4a51a80d884cd5db569886910", size = 160995 },
+    { url = "https://files.pythonhosted.org/packages/96/63/900c27cfe8be1a1f2433fc77cd46771cf26ba57e6bdc7cf9e63644a61863/websockets-14.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0a52a6d7cf6938e04e9dceb949d35fbdf58ac14deea26e685ab6368e73744e4c", size = 170543 },
+    { url = "https://files.pythonhosted.org/packages/00/8b/bec2bdba92af0762d42d4410593c1d7d28e9bfd952c97a3729df603dc6ea/websockets-14.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9f05702e93203a6ff5226e21d9b40c037761b2cfb637187c9802c10f58e40473", size = 169546 },
+    { url = "https://files.pythonhosted.org/packages/6b/a9/37531cb5b994f12a57dec3da2200ef7aadffef82d888a4c29a0d781568e4/websockets-14.2-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:22441c81a6748a53bfcb98951d58d1af0661ab47a536af08920d129b4d1c3473", size = 169911 },
+    { url = "https://files.pythonhosted.org/packages/60/d5/a6eadba2ed9f7e65d677fec539ab14a9b83de2b484ab5fe15d3d6d208c28/websockets-14.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:efd9b868d78b194790e6236d9cbc46d68aba4b75b22497eb4ab64fa640c3af56", size = 170183 },
+    { url = "https://files.pythonhosted.org/packages/76/57/a338ccb00d1df881c1d1ee1f2a20c9c1b5b29b51e9e0191ee515d254fea6/websockets-14.2-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:1a5a20d5843886d34ff8c57424cc65a1deda4375729cbca4cb6b3353f3ce4142", size = 169623 },
+    { url = "https://files.pythonhosted.org/packages/64/22/e5f7c33db0cb2c1d03b79fd60d189a1da044e2661f5fd01d629451e1db89/websockets-14.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:34277a29f5303d54ec6468fb525d99c99938607bc96b8d72d675dee2b9f5bf1d", size = 169583 },
+    { url = "https://files.pythonhosted.org/packages/aa/2e/2b4662237060063a22e5fc40d46300a07142afe30302b634b4eebd717c07/websockets-14.2-cp311-cp311-win32.whl", hash = "sha256:02687db35dbc7d25fd541a602b5f8e451a238ffa033030b172ff86a93cb5dc2a", size = 163969 },
+    { url = "https://files.pythonhosted.org/packages/94/a5/0cda64e1851e73fc1ecdae6f42487babb06e55cb2f0dc8904b81d8ef6857/websockets-14.2-cp311-cp311-win_amd64.whl", hash = "sha256:862e9967b46c07d4dcd2532e9e8e3c2825e004ffbf91a5ef9dde519ee2effb0b", size = 164408 },
+    { url = "https://files.pythonhosted.org/packages/c1/81/04f7a397653dc8bec94ddc071f34833e8b99b13ef1a3804c149d59f92c18/websockets-14.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:1f20522e624d7ffbdbe259c6b6a65d73c895045f76a93719aa10cd93b3de100c", size = 163096 },
+    { url = "https://files.pythonhosted.org/packages/ec/c5/de30e88557e4d70988ed4d2eabd73fd3e1e52456b9f3a4e9564d86353b6d/websockets-14.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:647b573f7d3ada919fd60e64d533409a79dcf1ea21daeb4542d1d996519ca967", size = 160758 },
+    { url = "https://files.pythonhosted.org/packages/e5/8c/d130d668781f2c77d106c007b6c6c1d9db68239107c41ba109f09e6c218a/websockets-14.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6af99a38e49f66be5a64b1e890208ad026cda49355661549c507152113049990", size = 160995 },
+    { url = "https://files.pythonhosted.org/packages/a6/bc/f6678a0ff17246df4f06765e22fc9d98d1b11a258cc50c5968b33d6742a1/websockets-14.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:091ab63dfc8cea748cc22c1db2814eadb77ccbf82829bac6b2fbe3401d548eda", size = 170815 },
+    { url = "https://files.pythonhosted.org/packages/d8/b2/8070cb970c2e4122a6ef38bc5b203415fd46460e025652e1ee3f2f43a9a3/websockets-14.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b374e8953ad477d17e4851cdc66d83fdc2db88d9e73abf755c94510ebddceb95", size = 169759 },
+    { url = "https://files.pythonhosted.org/packages/81/da/72f7caabd94652e6eb7e92ed2d3da818626e70b4f2b15a854ef60bf501ec/websockets-14.2-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a39d7eceeea35db85b85e1169011bb4321c32e673920ae9c1b6e0978590012a3", size = 170178 },
+    { url = "https://files.pythonhosted.org/packages/31/e0/812725b6deca8afd3a08a2e81b3c4c120c17f68c9b84522a520b816cda58/websockets-14.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:0a6f3efd47ffd0d12080594f434faf1cd2549b31e54870b8470b28cc1d3817d9", size = 170453 },
+    { url = "https://files.pythonhosted.org/packages/66/d3/8275dbc231e5ba9bb0c4f93144394b4194402a7a0c8ffaca5307a58ab5e3/websockets-14.2-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:065ce275e7c4ffb42cb738dd6b20726ac26ac9ad0a2a48e33ca632351a737267", size = 169830 },
+    { url = "https://files.pythonhosted.org/packages/a3/ae/e7d1a56755ae15ad5a94e80dd490ad09e345365199600b2629b18ee37bc7/websockets-14.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e9d0e53530ba7b8b5e389c02282f9d2aa47581514bd6049d3a7cffe1385cf5fe", size = 169824 },
+    { url = "https://files.pythonhosted.org/packages/b6/32/88ccdd63cb261e77b882e706108d072e4f1c839ed723bf91a3e1f216bf60/websockets-14.2-cp312-cp312-win32.whl", hash = "sha256:20e6dd0984d7ca3037afcb4494e48c74ffb51e8013cac71cf607fffe11df7205", size = 163981 },
+    { url = "https://files.pythonhosted.org/packages/b3/7d/32cdb77990b3bdc34a306e0a0f73a1275221e9a66d869f6ff833c95b56ef/websockets-14.2-cp312-cp312-win_amd64.whl", hash = "sha256:44bba1a956c2c9d268bdcdf234d5e5ff4c9b6dc3e300545cbe99af59dda9dcce", size = 164421 },
+    { url = "https://files.pythonhosted.org/packages/82/94/4f9b55099a4603ac53c2912e1f043d6c49d23e94dd82a9ce1eb554a90215/websockets-14.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:6f1372e511c7409a542291bce92d6c83320e02c9cf392223272287ce55bc224e", size = 163102 },
+    { url = "https://files.pythonhosted.org/packages/8e/b7/7484905215627909d9a79ae07070057afe477433fdacb59bf608ce86365a/websockets-14.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:4da98b72009836179bb596a92297b1a61bb5a830c0e483a7d0766d45070a08ad", size = 160766 },
+    { url = "https://files.pythonhosted.org/packages/a3/a4/edb62efc84adb61883c7d2c6ad65181cb087c64252138e12d655989eec05/websockets-14.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f8a86a269759026d2bde227652b87be79f8a734e582debf64c9d302faa1e9f03", size = 160998 },
+    { url = "https://files.pythonhosted.org/packages/f5/79/036d320dc894b96af14eac2529967a6fc8b74f03b83c487e7a0e9043d842/websockets-14.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:86cf1aaeca909bf6815ea714d5c5736c8d6dd3a13770e885aafe062ecbd04f1f", size = 170780 },
+    { url = "https://files.pythonhosted.org/packages/63/75/5737d21ee4dd7e4b9d487ee044af24a935e36a9ff1e1419d684feedcba71/websockets-14.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a9b0f6c3ba3b1240f602ebb3971d45b02cc12bd1845466dd783496b3b05783a5", size = 169717 },
+    { url = "https://files.pythonhosted.org/packages/2c/3c/bf9b2c396ed86a0b4a92ff4cdaee09753d3ee389be738e92b9bbd0330b64/websockets-14.2-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:669c3e101c246aa85bc8534e495952e2ca208bd87994650b90a23d745902db9a", size = 170155 },
+    { url = "https://files.pythonhosted.org/packages/75/2d/83a5aca7247a655b1da5eb0ee73413abd5c3a57fc8b92915805e6033359d/websockets-14.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:eabdb28b972f3729348e632ab08f2a7b616c7e53d5414c12108c29972e655b20", size = 170495 },
+    { url = "https://files.pythonhosted.org/packages/79/dd/699238a92761e2f943885e091486378813ac8f43e3c84990bc394c2be93e/websockets-14.2-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:2066dc4cbcc19f32c12a5a0e8cc1b7ac734e5b64ac0a325ff8353451c4b15ef2", size = 169880 },
+    { url = "https://files.pythonhosted.org/packages/c8/c9/67a8f08923cf55ce61aadda72089e3ed4353a95a3a4bc8bf42082810e580/websockets-14.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ab95d357cd471df61873dadf66dd05dd4709cae001dd6342edafc8dc6382f307", size = 169856 },
+    { url = "https://files.pythonhosted.org/packages/17/b1/1ffdb2680c64e9c3921d99db460546194c40d4acbef999a18c37aa4d58a3/websockets-14.2-cp313-cp313-win32.whl", hash = "sha256:a9e72fb63e5f3feacdcf5b4ff53199ec8c18d66e325c34ee4c551ca748623bbc", size = 163974 },
+    { url = "https://files.pythonhosted.org/packages/14/13/8b7fc4cb551b9cfd9890f0fd66e53c18a06240319915533b033a56a3d520/websockets-14.2-cp313-cp313-win_amd64.whl", hash = "sha256:b439ea828c4ba99bb3176dc8d9b933392a2413c0f6b149fdcba48393f573377f", size = 164420 },
+    { url = "https://files.pythonhosted.org/packages/7b/c8/d529f8a32ce40d98309f4470780631e971a5a842b60aec864833b3615786/websockets-14.2-py3-none-any.whl", hash = "sha256:7a6ceec4ea84469f15cf15807a747e9efe57e369c384fa86e022b3bea679b79b", size = 157416 },
 ]
 
 [[package]]


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #N/A

## Introduced changes

<!-- A brief description of the changes -->

- Add a new `--websocket-url` option to the price pusher to publish on the API websocket endpoint
- Websocket publishing supports authentication by sending `login` message

_TODO_ 
- pass the session in the api client instead of opening a new connection every time
- add `--burst` mode to price pusher to send data in the channel as soon as its available instead of waiting to produce a batch

##

- [ ] This PR contains breaking changes

<!-- List of all breaking changes -->
