### PR TITLE
fix: build command typo README.md

### DIFF
--- a/lmax-connector/README.md
+++ b/lmax-connector/README.md
@@ -89,7 +89,7 @@ The service will:
 1. Build the Docker image:
 
 ```bash
-ddocker build -t lmax-connector:latest -f lmax-connector/Dockerfile .
+docker build -t lmax-connector:latest -f lmax-connector/Dockerfile .
 ```
 
 2. Run the Docker container:


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #

## Introduced changes

<!-- A brief description of the changes -->

- Corrected "ddocker build" to "docker build"

##

- [ ] This PR contains breaking changes

<!-- List of all breaking changes -->
