### PR TITLE
docs: fix typos

### DIFF
--- a/checkpointer/README.md
+++ b/checkpointer/README.md
@@ -4,7 +4,7 @@ Service used to automatically create checkpoints periodically for a set of pairs
 
 ### Usage
 
-The service is ran through the CLI.
+The service is run through the CLI.
 
 To specify for which assets you want to set checkpoints, you will need to provide a yaml configuration file formatted as follow:
 

--- a/lp-pricer/README.md
+++ b/lp-pricer/README.md
@@ -4,7 +4,7 @@ Service used to price Defi Pools using the `LpFetcher` from the SDK.
 
 ### Usage
 
-The service is ran through the CLI, to have more information you can use the `--help` command:
+The service is run through the CLI, to have more information you can use the `--help` command:
 
 ```bash
 .venv ❯ uv run lp_pricer --help

--- a/merkle-maker/README.md
+++ b/merkle-maker/README.md
@@ -4,7 +4,7 @@ Service used to publish the latest Merkle Feed onchain and the associated data o
 
 ### Usage
 
-The service is ran through the CLI, to have more information you can use the `--help` command:
+The service is run through the CLI, to have more information you can use the `--help` command:
 
 ```bash
 .venv ❯ uv run merkle_maker --help

--- a/price-pusher/README.md
+++ b/price-pusher/README.md
@@ -3,7 +3,7 @@
 
 ## Usage
 
-The price-pusher service is ran through the ClI, to have more information you can use the `--help` command:
+The price-pusher service is run through the ClI, to have more information you can use the `--help` command:
 
 ```bash
 .venv ❯ python price_pusher/main.py --help

--- a/vrf-listener/README.md
+++ b/vrf-listener/README.md
@@ -4,7 +4,7 @@ Service used to listen for VRF requests and handle them.
 
 ## Usage
 
-The service is ran through the CLI, to have more information you can use the `--help` command:
+The service is run through the CLI, to have more information you can use the `--help` command:
 
 ```bash
 .venv ❯ python vrf_listener/main.py --help


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #

## Introduced changes

<!-- A brief description of the changes -->

- Corrected "ran" to "run" in multiple docs for proper passive voice usage (e.g., "is ran" → "is run").

##

- [ ] This PR contains breaking changes

<!-- List of all breaking changes -->
