### PR TITLE
feat(helm): support keystoreSecrets + extraVolumes/extraVolumeMounts

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -66,6 +66,15 @@ spec:
           volumeMounts:
             - name: openapi-volume
               mountPath: /app/openapi
+            {{- range .Values.keystoreSecrets }}
+            - name: keystore-{{ .secretName }}
+              mountPath: {{ .mountPath }}/{{ .fileName }}
+              subPath: keystore
+              readOnly: true
+            {{- end }}
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
@@ -82,3 +91,11 @@ spec:
       volumes:
         - name: openapi-volume
           emptyDir: {}
+        {{- range .Values.keystoreSecrets }}
+        - name: keystore-{{ .secretName }}
+          secret:
+            secretName: {{ .secretName }}
+        {{- end }}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}

--- a/helm/templates/externalSecret.yaml
+++ b/helm/templates/externalSecret.yaml
@@ -16,3 +16,25 @@ spec:
     - extract:
         key: {{ .Values.gcpSecrets.externalSecret.secretPath }}
 {{- end }}
+
+{{- range .Values.keystoreSecrets }}
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: {{ .secretName }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  refreshInterval: "24h"
+  secretStoreRef:
+    name: {{ $.Values.gcpSecrets.secretStore.name }}
+    kind: SecretStore
+  target:
+    name: {{ .secretName }}
+  data:
+    - secretKey: keystore
+      remoteRef:
+        key: {{ .secretName }}
+        decodingStrategy: None
+{{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -113,6 +113,21 @@ gcpSecrets:
 envFromSecret: {}
     # secretName: "monitoring-secrets"
 
+# Binary keystore-like secrets pulled from GCP Secret Manager and mounted
+# read-only into the container. Each entry produces one ExternalSecret +
+# one volume mount under `mountPath/fileName`.
+# Example:
+#   keystoreSecrets:
+#     - secretName: price-pusher-miden-keystore
+#       fileName: "9190688567612556222"
+#       mountPath: /secrets/miden/keystore
+keystoreSecrets: []
+
+# Extra arbitrary volumes / volume mounts the deployment should attach
+# (e.g. an emptyDir for runtime caches that don't need persistence).
+extraVolumes: []
+extraVolumeMounts: []
+
 terminationGracePeriodSeconds: 60
 
 env: []


### PR DESCRIPTION
## Summary

Adds three optional value blocks to the pragma-sdk Helm chart:

- **`keystoreSecrets`** — list of GCP-backed binary secrets. Each entry produces one `ExternalSecret` + a read-only volume mount at `\${mountPath}/\${fileName}`. Pattern aligned with the existing `pragma-miden` helm chart.
- **`extraVolumes` / `extraVolumeMounts`** — free-form passthroughs for runtime caches (e.g. an `emptyDir` for the Miden SQLite cache).

All three default to empty, so existing deployments (price-pusher, checkpointer, vrf-listener, lp-pricer, lmax-connector, pragma-utils) render byte-identical to before.

## Why

The upcoming Miden-enabled price-pusher (2.13.0a1) needs three secrets mounted into the pod:

| Secret | Mount target |
|--------|--------------|
| `price-pusher-miden-keystore` (binary publisher key) | `/secrets/miden/keystore/9190688567612556222` |
| `price-pusher-miden-key-index` | `/secrets/miden/keystore/key_index.json` |
| `price-pusher-miden-config` (`pragma_miden.json`) | `/secrets/miden/config/pragma_miden.json` |

Plus an empty writable volume for the local SQLite store cache. Without this PR, devops would have to fork the chart.

## Test plan

- [x] `git diff --stat helm/` → only 3 files touched
- [ ] Local `helm template` smoke render (no helm installed locally — to validate during devops merge)
- [ ] Once merged, devops PR can bump the price-pusher service values

🤖 Generated with [Claude Code](https://claude.com/claude-code)