### PR TITLE
chore(miden): pin pm-publisher>=0.1.0a5 + relock (remote prover + ECDSA, 60-120s → ~3s)

### DIFF
--- a/pragma-sdk/pyproject.toml
+++ b/pragma-sdk/pyproject.toml
@@ -53,7 +53,7 @@ docs = [
 ]
 
 miden = [
-    "pm-publisher>=0.1.0a4",
+    "pm-publisher>=0.1.0a5",
 ]
 
 dev = [

--- a/pragma-sdk/uv.lock
+++ b/pragma-sdk/uv.lock
@@ -3,8 +3,7 @@ revision = 3
 requires-python = ">=3.11, <3.13"
 
 [options]
-exclude-newer = "2026-04-23T15:18:30.309196Z"
-exclude-newer-span = "P7D"
+exclude-newer = "2026-06-14T00:00:00Z"
 
 [[package]]
 name = "accessible-pygments"
@@ -1253,11 +1252,11 @@ wheels = [
 
 [[package]]
 name = "pm-publisher"
-version = "0.1.0a1"
+version = "0.1.0a5"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/00/38/644b97e9216c9657196cbea40cef49bdcf8a09c507b7cb1e4312b90f26e2/pm_publisher-0.1.0a1-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:411ef0e27db6319292a72af6f8c83d112d672640e359b755d6ae3a03e2037738", size = 10049222, upload-time = "2026-03-04T18:03:25.047Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/a1/d028f844e2dbaecd545ea1b2754fd3ce1180109116e7d0ba49173c331792/pm_publisher-0.1.0a1-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:15b1913625b1b64bd780d8abde6f6f375791c6ce6a99525c8dddbe74b232c59f", size = 11021661, upload-time = "2026-03-04T18:03:27.897Z" },
+    { url = "https://files.pythonhosted.org/packages/05/75/13b1726dae0b1c84dda526eb972ac4f2cb984a5931edb74e62cb6eae7621/pm_publisher-0.1.0a5-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:09139f0cf275f634042090a37f782aaf6dde8383695bbffd034ed4f8ae51c5ff", size = 10613527, upload-time = "2026-06-13T10:57:20.148Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/08/92cf90000dc81a8d49ae394c78da4d919acc2f65a239cb434c3c003f038a/pm_publisher-0.1.0a5-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:540313a8e85d631fc66de4b2938be54eb820f86790616d5b586754fab283224f", size = 11981012, upload-time = "2026-06-13T10:57:21.986Z" },
 ]
 
 [[package]]
@@ -1369,7 +1368,7 @@ requires-dist = [
     { name = "moto", extras = ["s3", "secretsmanager"], marker = "extra == 'dev'", specifier = ">=4.2.5" },
     { name = "mypy", marker = "extra == 'typing'", specifier = ">=1.10" },
     { name = "pallets-sphinx-themes", marker = "extra == 'docs'", specifier = ">=2.1.3" },
-    { name = "pm-publisher", marker = "extra == 'miden'", specifier = ">=0.1.0a1" },
+    { name = "pm-publisher", marker = "extra == 'miden'", specifier = ">=0.1.0a5" },
     { name = "poethepoet", marker = "extra == 'dev'", specifier = ">=0.21.1" },
     { name = "pydantic", specifier = ">=2.7.4" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.2.2" },

--- a/price-pusher/uv.lock
+++ b/price-pusher/uv.lock
@@ -3,8 +3,7 @@ revision = 3
 requires-python = ">=3.11, <3.13"
 
 [options]
-exclude-newer = "2026-05-03T17:04:05.628378Z"
-exclude-newer-span = "P7D"
+exclude-newer = "2026-06-14T00:00:00Z"
 
 [[package]]
 name = "aiohappyeyeballs"
@@ -1107,11 +1106,11 @@ wheels = [
 
 [[package]]
 name = "pm-publisher"
-version = "0.1.0a2"
+version = "0.1.0a5"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/24/c2/d770c19bea334abcd3e3fd771c0a27e56e8485c4cd7fadc5ee94236cdbb8/pm_publisher-0.1.0a2-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:5da80a50789d993e2ca5939ee8cb15f72c5194aa7f1fb6f87a70c9fce0cb1515", size = 10569419, upload-time = "2026-04-30T21:32:08.519Z" },
-    { url = "https://files.pythonhosted.org/packages/86/bf/de007124fa74e6ad6ad2a557fe08b96607f76ebb0dc3f2f16c844af0dc8a/pm_publisher-0.1.0a2-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:770bf5bc092d1ddf3daf9efd3d0c992321c8449125d19c8743f7a041d8b90c26", size = 11929948, upload-time = "2026-04-30T21:32:10.516Z" },
+    { url = "https://files.pythonhosted.org/packages/05/75/13b1726dae0b1c84dda526eb972ac4f2cb984a5931edb74e62cb6eae7621/pm_publisher-0.1.0a5-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:09139f0cf275f634042090a37f782aaf6dde8383695bbffd034ed4f8ae51c5ff", size = 10613527, upload-time = "2026-06-13T10:57:20.148Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/08/92cf90000dc81a8d49ae394c78da4d919acc2f65a239cb434c3c003f038a/pm_publisher-0.1.0a5-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:540313a8e85d631fc66de4b2938be54eb820f86790616d5b586754fab283224f", size = 11981012, upload-time = "2026-06-13T10:57:21.986Z" },
 ]
 
 [[package]]
@@ -1196,7 +1195,7 @@ requires-dist = [
     { name = "moto", extras = ["s3", "secretsmanager"], marker = "extra == 'dev'", specifier = ">=4.2.5" },
     { name = "mypy", marker = "extra == 'typing'", specifier = ">=1.10" },
     { name = "pallets-sphinx-themes", marker = "extra == 'docs'", specifier = ">=2.1.3" },
-    { name = "pm-publisher", marker = "extra == 'miden'", specifier = ">=0.1.0a2" },
+    { name = "pm-publisher", marker = "extra == 'miden'", specifier = ">=0.1.0a5" },
     { name = "poethepoet", marker = "extra == 'dev'", specifier = ">=0.21.1" },
     { name = "pydantic", specifier = ">=2.7.4" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.2.2" },


### PR DESCRIPTION
## What
Pulls `pm-publisher 0.1.0a5` into the SDK / price-pusher. That wheel (pragma-miden #59) carries the Miden publish latency work, both validated end-to-end on testnet:
- **delegated proving** to Miden's hosted remote prover → 60-120s & >4Gi RSS in-process **→ ~4-5s, off-pod**
- **publisher auth Falcon512 → ECDSA** → **~2.7-3.9s**

## Changes
- `pragma-sdk/pyproject.toml` — miden extra pin `pm-publisher>=0.1.0a4` → `>=0.1.0a5`
- `pragma-sdk/uv.lock` — pm-publisher `0.1.0a1` → `0.1.0a5`
- `price-pusher/uv.lock` — pm-publisher `0.1.0a2` → `0.1.0a5` (this is the lock the prod image installs from via `uv sync --all-extras` in `infra/price-pusher/onchain/Dockerfile`)

Only `pm-publisher` changed in both locks (`--upgrade-package pm-publisher`).

## Lock note
a5 was published <7 days ago, so the rolling `exclude-newer = "7 days"` (global uv config) excluded it. Relocked with an explicit `--exclude-newer 2026-06-14`; the fixed cutoff reverts to the rolling span on the next normal relock. `exclude-newer` only filters at lock time, not at `uv sync` — the prod build installs the exact pinned a5 from the lock.

## Rollout
- **Remote prover** activates immediately on deploy, even on the existing Falcon publisher — no on-chain change. This is the big free win.
- **ECDSA** is dormant until we deploy a fresh ECDSA publisher (separate on-chain rollout: redeploy oracle+publisher, re-register, update config + oracle-explorer frontend).
- ⚠️ Prod price-pusher pod needs egress to `tx-prover.testnet.miden.io`.

Rides on the current unreleased `2.13.0a10` dev version (no extra version bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)