### PR TITLE
feat(miden): decoupled periodic publish loop (configurable ~3s cadence)

### DIFF
--- a/price-pusher/price_pusher/core/pusher.py
+++ b/price-pusher/price_pusher/core/pusher.py
@@ -41,17 +41,6 @@ class PricePusher(IPricePusher):
         self.onchain_lock = asyncio.Lock()
         self.on_successful_push = on_successful_push
         self.miden_client = miden_client
-        # At most one Miden publish in flight at a time. New ticks skip rather
-        # than queue when one is already running — that way a hung Miden
-        # publish_batch never accumulates zombie threads behind it.
-        self._miden_sem: Optional[asyncio.Semaphore] = (
-            asyncio.Semaphore(1) if miden_client is not None else None
-        )
-        # asyncio.create_task() returns a Task that the event loop only keeps
-        # a weak reference to. If our caller doesn't hold a strong ref, the
-        # GC can collect the task mid-execution and cancel it silently.
-        # Cf. https://docs.python.org/3/library/asyncio-task.html#asyncio.create_task
-        self._miden_tasks: set[asyncio.Task] = set()
 
         # Setup RPC health monitoring if using onchain client
         if isinstance(self.client, PragmaOnChainClient):
@@ -106,13 +95,9 @@ class PricePusher(IPricePusher):
             if self.on_successful_push:
                 self.on_successful_push()
 
-            # Miden publishing — fire-and-forget, isolated from Starknet.
-            # Hold a strong reference in self._miden_tasks until done, so
-            # the task isn't garbage-collected mid-publish.
-            if self.miden_client is not None:
-                task = asyncio.create_task(self._publish_to_miden(entries))
-                self._miden_tasks.add(task)
-                task.add_done_callback(self._miden_tasks.discard)
+            # Miden publishing is fully decoupled from the Starknet tick — it
+            # runs on its own periodic loop (Orchestrator._miden_service) so it
+            # can publish at a much higher cadence than Starknet pushes.
             return response
 
         except Exception as e:
@@ -135,26 +120,21 @@ class PricePusher(IPricePusher):
 
             return None
 
-    async def _publish_to_miden(self, entries: List[Entry]) -> None:
+    async def publish_to_miden(self, entries: List[Entry]) -> None:
         """
-        Publish entries to Miden in the background.
-        Completely isolated — any failure here has zero impact on the Starknet loop.
-        Skipped when a previous batch is still in flight.
+        Publish the latest prices to Miden in a single batched transaction.
+
+        Fully isolated — any failure here has zero impact on the Starknet loop.
+        Called serially by the orchestrator's periodic Miden loop (no overlap),
+        so no in-flight guard is needed here.
         """
-        if self._miden_sem is None or self._miden_sem.locked():
-            if self._miden_sem is not None:
-                logger.warning(
-                    "🌐 MIDEN: previous batch still in flight, skipping this tick"
-                )
+        if self.miden_client is None or not entries:
             return
-        # Pragma publishes one Starknet entry per (pair, source), so a tick
-        # batch can contain e.g. BTC/USD × 5 sources, ETH/USD × 5 sources, ...
-        # Miden has no notion of "source": publish_entry overwrites the
-        # storage map at faucet_id, so duplicate calls within the same tx
-        # are wasted work, and the Miden prover cost grows linearly with
-        # script length. 22 raw entries (5 pairs × ~4 sources) was taking
-        # >60s and >4Gi RSS to prove. Aggregate one MidenEntry per pair
-        # using the median price (matches Pragma's on-chain aggregation).
+        # Pragma emits one entry per (pair, source); Miden has no notion of
+        # "source" (publish_entry overwrites the storage map at faucet_id), and
+        # the prover cost grows with the number of publish_entry calls. Aggregate
+        # one MidenEntry per pair using the median price (matches Pragma's
+        # on-chain aggregation).
         from statistics import median
 
         per_pair: dict[str, list[MidenEntry]] = {}
@@ -173,10 +153,9 @@ class PricePusher(IPricePusher):
         ]
         if not miden_entries:
             return
-        async with self._miden_sem:
-            try:
-                results = await self.miden_client.publish_entries(miden_entries)
-                ok = sum(results)
-                logger.info(f"🌐 MIDEN: published {ok}/{len(miden_entries)} entries")
-            except Exception as e:
-                logger.error(f"🌐 MIDEN: publish failed (Starknet unaffected): {e}")
+        try:
+            results = await self.miden_client.publish_entries(miden_entries)
+            ok = sum(results)
+            logger.info(f"🌐 MIDEN: published {ok}/{len(miden_entries)} entries")
+        except Exception as e:
+            logger.error(f"🌐 MIDEN: publish failed (Starknet unaffected): {e}")

--- a/price-pusher/price_pusher/main.py
+++ b/price-pusher/price_pusher/main.py
@@ -47,6 +47,7 @@ async def main(
     health_server_type: str = "fastapi",
     max_seconds_without_push: Optional[int] = None,
     evm_rpc_urls: Optional[List[str]] = None,
+    miden_publish_interval: int = 3,
     miden_network: Optional[str] = None,
     miden_oracle_id: Optional[str] = None,
     miden_config_path: Optional[str] = None,
@@ -118,6 +119,7 @@ async def main(
     orchestrator = Orchestrator(
         poller=poller,
         poller_refresh_interval=poller_refresh_interval,
+        miden_publish_interval=miden_publish_interval,
         listeners=_create_listeners(price_configs, pragma_client),
         pusher=pusher,
         health_server=health_server,
@@ -296,6 +298,14 @@ def _create_client(
     help="Enable Miden publishing. Specify network: testnet, devnet, or local.",
 )
 @click.option(
+    "--miden-publish-interval",
+    type=click.IntRange(min=1),
+    required=False,
+    default=3,
+    help="Target seconds between Miden publishes (decoupled from Starknet). "
+    "Default 3. Publishes back-to-back if a publish takes longer than this.",
+)
+@click.option(
     "--miden-oracle-id",
     type=click.STRING,
     required=False,
@@ -341,6 +351,7 @@ def cli_entrypoint(
     health_server_type: str,
     max_seconds_without_push: Optional[int],
     evm_rpc_url: Sequence[str],
+    miden_publish_interval: int,
     miden_network: Optional[str],
     miden_oracle_id: Optional[str],
     miden_config_path: Optional[str],
@@ -387,6 +398,7 @@ def cli_entrypoint(
             health_server_type=health_server_type,
             max_seconds_without_push=max_seconds_without_push,
             evm_rpc_urls=evm_rpc_urls,
+            miden_publish_interval=miden_publish_interval,
             miden_network=miden_network,
             miden_oracle_id=miden_oracle_id,
             miden_config_path=miden_config_path,

--- a/price-pusher/price_pusher/orchestrator.py
+++ b/price-pusher/price_pusher/orchestrator.py
@@ -1,5 +1,6 @@
 import logging
 import asyncio
+import time
 
 from typing import List, Dict, Optional
 
@@ -38,6 +39,7 @@ class Orchestrator:
         listeners: List[PriceListener],
         pusher: PricePusher,
         poller_refresh_interval: int = 5,
+        miden_publish_interval: int = 3,
         health_server: Optional[HealthServer] = None,
     ) -> None:
         self.poller = poller
@@ -47,6 +49,16 @@ class Orchestrator:
 
         # Time between poller refresh
         self.poller_refresh_interval = poller_refresh_interval
+
+        # Target interval (seconds) between Miden publishes. The Miden loop is
+        # decoupled from the Starknet tick and publishes the latest polled
+        # prices as often as this allows (back-to-back if a publish takes
+        # longer than the interval).
+        self.miden_publish_interval = miden_publish_interval
+
+        # Snapshot of the most recent full poll, fed to the Miden loop. Never
+        # mutated in place — replaced wholesale on each poll.
+        self.last_polled_entries: List[Entry] = []
 
         # Contains the latest prices for each sources
         self.latest_prices: LatestOrchestratorPairPrices = {}
@@ -77,6 +89,10 @@ class Orchestrator:
             self._listener_services(),
             self._pusher_service(),
         ]
+
+        # Decoupled Miden publish loop — only when Miden publishing is enabled.
+        if self.pusher.miden_client is not None:
+            tasks.append(self._miden_service())
 
         # Start health server if configured
         if self.health_server:
@@ -136,6 +152,20 @@ class Orchestrator:
             await self.pusher.update_price_feeds(entries_to_push)
             self.push_queue.task_done()
 
+    async def _miden_service(self) -> None:
+        """
+        Periodically publish the latest polled prices to Miden, decoupled from
+        the Starknet push cadence. Aims for one publish every
+        `miden_publish_interval` seconds; if a publish takes longer, the next
+        starts immediately (calls are awaited serially, so they never overlap).
+        """
+        while True:
+            start = time.monotonic()
+            if self.last_polled_entries:
+                await self.pusher.publish_to_miden(self.last_polled_entries)
+            elapsed = time.monotonic() - start
+            await asyncio.sleep(max(0.0, self.miden_publish_interval - elapsed))
+
     def _flush_entries_for_assets(
         self, pairs_per_type: Dict[DataTypes, List[Pair]]
     ) -> List[Entry]:
@@ -186,6 +216,8 @@ class Orchestrator:
         For spot price, we store the latest price for each source.
         For future price, we store the latest price for each source for each expiry received.
         """
+        # Keep a fresh snapshot of the full poll for the decoupled Miden loop.
+        self.last_polled_entries = entries
 
         for entry in entries:
             pair_id = entry.get_pair_id()


### PR DESCRIPTION
## What
Decouples Miden publishing from the Starknet push tick so it can run at a high, configurable cadence.

Until now Miden publishing was fire-and-forget right after each Starknet `publish_many`, so its frequency was tied to the Starknet trigger (price deviation or ~30 min staleness floor — measured ~30 min between Miden publishes in prod). Now that proving is off-pod and fast (remote prover, ~10s and dropping with ECDSA), the cadence should be driven independently.

## How
- **orchestrator**: keeps a fresh `last_polled_entries` snapshot (set on every poll, ~5s), and runs a dedicated `_miden_service()` loop that publishes those prices every `--miden-publish-interval` seconds. Started only when Miden is enabled. It subtracts elapsed time so it publishes back-to-back if a publish takes longer than the interval (no overlap — calls are awaited serially).
- **pusher**: `_publish_to_miden` → public `publish_to_miden(entries)` (per-pair median aggregation unchanged); removed the Starknet-coupled fire-and-forget call and the now-unused semaphore + task-set machinery.
- **main**: new `--miden-publish-interval` option (default 3s, min 1).

## Notes
- Effective cadence is bounded by publish latency: ~10s today on the Falcon publisher, approaching the configured ~3s once the publisher is on ECDSA. Literal 3-4s also depends on Miden's single-account nonce/block-inclusion behaviour.
- The Starknet path is untouched; Miden remains fully isolated (failures logged, never affect Starknet).

## Test
- `ruff` clean; `pytest tests/unit/test_orchestrator.py` → 8 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)