### PR TITLE
fix(miden): reconcile publisher account on commitment conflict, then retry

### DIFF
--- a/pragma-sdk/pragma_sdk/miden/client.py
+++ b/pragma-sdk/pragma_sdk/miden/client.py
@@ -284,7 +284,8 @@ class PragmaMidenClient:
             await self.initialize()
 
         batch = [(e.pair, e.price, e.decimals, e.timestamp) for e in entries]
-        try:
+
+        async def _submit() -> None:
             await asyncio.wait_for(
                 asyncio.to_thread(
                     pm_publisher.publish_batch,
@@ -295,6 +296,9 @@ class PragmaMidenClient:
                 ),
                 timeout=PUBLISH_BATCH_TIMEOUT_S,
             )
+
+        try:
+            await _submit()
             return [True] * len(entries)
         except asyncio.TimeoutError:
             logger.error(
@@ -303,6 +307,30 @@ class PragmaMidenClient:
             )
             return [False] * len(entries)
         except Exception as e:
+            # A reverted/dropped tx leaves our local account commitment ahead of
+            # the chain's, so the node then rejects with
+            # IncorrectAccountInitialCommitment ("conflicts with current mempool
+            # state"). sync_state can't recover it (the node's lower-nonce
+            # committed account is filtered out by a nonce gate), but
+            # import_account_by_id re-fetches + overwrites the account. We only
+            # need this when the account has actually diverged, so reconcile and
+            # retry once on that specific error rather than on every publish.
+            msg = str(e)
+            if (
+                "IncorrectAccountInitialCommitment" in msg
+                or "conflicts with current mempool state" in msg
+            ):
+                logger.warning(
+                    "Miden publisher account diverged from chain; reconciling and retrying..."
+                )
+                try:
+                    await self._import_publisher_account()
+                    await self.sync()
+                    await _submit()
+                    return [True] * len(entries)
+                except Exception as e2:
+                    logger.error(f"Miden publish still failing after reconcile: {e2}")
+                    return [False] * len(entries)
             logger.error(f"Failed to publish batch of {len(entries)} entries: {e}")
             return [False] * len(entries)
 


### PR DESCRIPTION
## Problem
The decoupled Miden publish loop gets stuck publishing `0/5`:
```
SubmitProvenTx ... IncorrectAccountInitialCommitment:
  transaction conflicts with current mempool state
  initial account commitment 0x77a0… does not match current 0x34de… for account 0xb82114…
```

## Root cause (verified against miden-client 0.14 source)
After a reverted/dropped tx, the local store keeps the **optimistically-advanced** account commitment (`apply_transaction` persists it at submit time). `sync_state` can **not** roll it back: `get_updated_public_accounts` only applies the node's account if its nonce is **strictly greater** than the local one (`rpc/mod.rs:377-380`), and the optimistic apply already advanced the local nonce — so the chain's correct (lower-nonce) committed state is filtered out. Every subsequent publish then builds on the stale commitment and is rejected forever.

## Fix
On that specific error, reconcile the publisher account via `_import_publisher_account()` → `import_account_by_id` (re-fetches the node's committed account and **overwrites** the local one, `overwrite=true`, bypassing the nonce gate) + `sync()`, then retry the publish once.

We reconcile **only when the account has actually diverged** (on the conflict), not before every publish — so the happy path (optimistic chaining on the reused client) is untouched and there's no extra RPC per tick.

Python-only → ships via a **price-pusher image rebuild**, no new pm-publisher wheel.

## Scope / caveat
Fixes the **stuck/diverged** case (reverted tx) — it now self-heals on the next tick instead of wedging. The **in-flight** case (publishing again while the previous tx is still uncommitted in the mempool) is bounded by the publish interval; pair with an interval ≥ commit time (pending Miden's guidance on single-account cadence). Cleaner long-term: do the same import+sync inside `publish_batch` Rust-side (next pm-publisher wheel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)