### PR TITLE
fix(miden): sync before each publish (stale tx-reference / expired publishes)

### DIFF
--- a/pragma-sdk/pragma_sdk/miden/client.py
+++ b/pragma-sdk/pragma_sdk/miden/client.py
@@ -298,6 +298,14 @@ class PragmaMidenClient:
             )
 
         try:
+            # Refresh the local chain view + publisher account state before
+            # building the tx. The decoupled Miden loop only publishes and never
+            # syncs, so without this the tx stays anchored to the startup-sync
+            # block; pm-publisher >=0.1.0a6 sets a 16-block tx expiration, which
+            # then makes every publish fail once the chain moves past it
+            # ("transaction expired ... InputNotesAlreadyConsumed"). a5 had no
+            # expiration so the missing sync was latent.
+            await self.sync()
             await _submit()
             return [True] * len(entries)
         except asyncio.TimeoutError:


### PR DESCRIPTION
## Symptom (prod, after the Miden 0.15 / a7 rollout)
Every Miden publish fails:
```
SubmitProvenTx ... InputNotesAlreadyConsumed ...
"transaction expired at block height 142391 but the block height limit was 142723"
```
The tx expiration is **frozen at 142391** while the chain climbs (142720→142723) — i.e. the tx is built against a stale reference block that never advances.

## Root cause
`Orchestrator._miden_service` (the decoupled Miden loop) only calls `publish_to_miden` — it **never syncs** the miden-client store. The store is synced once at `initialize()` and then never again, so the chain reference stays frozen at the startup block. `pm-publisher >=0.1.0a6` (#65) sets a **16-block tx expiration** in the publish script, so once the chain advances >16 blocks (~80s) past the startup block, every publish is born expired and the node rejects it. This was **latent under a5** (no expiration → stale-reference txs lingered but eventually committed); moving prod to the **0.15 a7** wheel turned it into a hard failure. The existing auto-reconcile only fires on `IncorrectAccountInitialCommitment`, not on this error, so it never recovers.

## Fix
`await self.sync()` at the top of `publish_entries`, before submitting — each tx now anchors to the current tip (and the publisher account state is current). The per-publish sync (~1-2s) is comfortably inside the 16-block (~80s) window.

## Rollout
Rebuild the price-pusher image (this is monorepo-local `pragma-sdk`) → roll out. The emptyDir store is wiped on the new pod, so the currently-diverged local account is re-imported fresh on startup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)