### PR TITLE
fix(price-pusher): keep Miden publishing alive when the Starknet path dies

### DIFF
--- a/price-pusher/price_pusher/core/pusher.py
+++ b/price-pusher/price_pusher/core/pusher.py
@@ -113,6 +113,20 @@ class PricePusher(IPricePusher):
                         return await self.update_price_feeds(entries)
 
             if self.consecutive_push_error >= CONSECUTIVES_PUSH_ERRORS_LIMIT:
+                # This fatal guard crashes the pod so k8s restarts it when the
+                # Starknet publish path is persistently broken. But when Miden
+                # publishing is enabled it shares this process, so crashing here
+                # would also take down the independent Miden loop. In that case,
+                # log and keep the loop retrying instead: the Starknet path
+                # self-heals once the condition clears (e.g. the publisher
+                # account is refunded), and Miden keeps publishing throughout.
+                if self.miden_client is not None:
+                    logger.error(
+                        f"⛔ PUSHER: Starknet publish still failing after "
+                        f"{self.consecutive_push_error} consecutive errors "
+                        "— keeping the process alive so Miden publishing continues."
+                    )
+                    return None
                 raise ValueError(
                     f"⛔ PUSHER: Failed to publish entries {self.consecutive_push_error} "
                     "times in a row. Something is wrong!"
@@ -157,5 +171,12 @@ class PricePusher(IPricePusher):
             results = await self.miden_client.publish_entries(miden_entries)
             ok = sum(results)
             logger.info(f"🌐 MIDEN: published {ok}/{len(miden_entries)} entries")
+            # Count Miden pushes toward liveness too. The health server is
+            # otherwise driven only by Starknet pushes, so if the Starknet path
+            # stops (e.g. out of funds) the liveness probe goes stale and k8s
+            # restarts the pod — which would kill this Miden loop. A live Miden
+            # feed keeps the pod healthy on its own.
+            if ok > 0 and self.on_successful_push:
+                self.on_successful_push()
         except Exception as e:
             logger.error(f"🌐 MIDEN: publish failed (Starknet unaffected): {e}")


### PR DESCRIPTION
## Symptom (prod)
When the Starknet publisher runs out of funds, publishing fails with `code 55 ... Resources bounds exceed balance`, and after 10 consecutive failures the whole process dies — **taking the Miden feed down with it**, even though Miden publishes fine (`🌐 MIDEN: published 5/5 entries`).

## Root cause — two couplings (Starknet → Miden)
The Miden loop and the Starknet publish path run in the **same process**. The code intended Miden to be decoupled, but only Miden→Starknet was isolated:

1. **In-process crash.** After `CONSECUTIVES_PUSH_ERRORS_LIMIT` errors, `PricePusher.update_price_feeds` raises `ValueError` → propagates through `Orchestrator._pusher_service` → `asyncio.gather` in `run_forever` → process exit → the Miden task is torn down.
2. **Liveness starvation.** The health server only advances (`update_last_push`) on **Starknet** pushes. So even without the crash, once Starknet stops the k8s liveness probe (`/` :8080) goes 503 after `max_seconds_without_push` → pod restart → Miden dies anyway.

## Fix (2 surgical edits in `core/pusher.py`)
1. When `miden_client` is set, the fatal guard **logs and keeps retrying** instead of raising — Starknet auto-heals once the account is refunded, Miden is never impacted. Standalone Starknet deployments keep the original fail-fast → k8s-restart behavior.
2. The Miden loop calls `on_successful_push()` on a successful publish, so a live Miden feed keeps the pod **healthy** on its own. (If both Starknet *and* Miden stop, health still goes stale → restart, which is what we want.)

No orchestrator change needed: with (1), nothing fatal propagates out of `_pusher_service` anymore.

## Tests
`py_compile` clean; no existing test asserts the fatal raise (only `consecutive_push_error == 0/1`), so nothing regresses.

## Rollout
Rebuild the price-pusher image (monorepo-local pragma-sdk) → roll out. Same pp-only cloudbuild as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)