### PR TITLE
fix(miden): don't let a sync RPC hiccup block publishing

### DIFF
--- a/pragma-sdk/pragma_sdk/miden/client.py
+++ b/pragma-sdk/pragma_sdk/miden/client.py
@@ -305,7 +305,20 @@ class PragmaMidenClient:
             # then makes every publish fail once the chain moves past it
             # ("transaction expired ... InputNotesAlreadyConsumed"). a5 had no
             # expiration so the missing sync was latent.
-            await self.sync()
+            #
+            # But a sync failure must NOT block publishing: the Miden testnet RPC
+            # flakes/rate-limits, and sync does far more RPC calls than the submit.
+            # The local store is usually recent enough that the tx still anchors
+            # within its 16-block expiration window, so on a sync error we log and
+            # submit anyway — it succeeds when the store is fresh, and only fails
+            # (retried next tick) if the store has actually drifted too far.
+            try:
+                await self.sync()
+            except Exception as e:
+                logger.warning(
+                    f"Miden sync before publish failed ({e}); "
+                    "submitting with the current local state."
+                )
             await _submit()
             return [True] * len(entries)
         except asyncio.TimeoutError:


### PR DESCRIPTION
## Symptom (prod)
Miden publishing stopped:
```
Failed to publish batch of 5 entries: Sync failed: Could not sync state: RPC error
```

## Cause
#294 added `await self.sync()` before every publish (needed so the tx doesn't anchor to a stale block and hit the 16-block expiration). But that made **sync a hard prerequisite for publishing** — any Miden-testnet RPC flake or rate-limit during sync now aborts the whole publish. And the decoupled Miden loop syncs every ~3s (far more RPC calls than the single submit), so sync is the most likely call to hit a transient error. The testnet RPC endpoint itself is up (`rpc.testnet.miden.io` → 200 from here), so this is transient instability / rate-limiting, not an outage.

## Fix
Make the pre-publish sync **best-effort**: on failure, log a warning and submit anyway. The local store is usually recent enough that the tx still anchors within its 16-block (~80s) expiration window, so:
- store fresh → publish succeeds despite the sync blip;
- store actually drifted too far → submit fails as before and is retried next tick.

Submitting with a slightly stale account is safe: a diverged account hits the existing reconcile-on-conflict path (`IncorrectAccountInitialCommitment`), and an over-expired tx is rejected node-side with nothing committed.

## Follow-up to consider (depends on log pattern)
If the errors are dominated by **rate-limiting** (not random flakes), we should also cut sync frequency — e.g. sync every N seconds instead of before every 3s publish (still well inside the 16-block window). Holding that until we see whether this resilience fix restores the feed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)