### PR TITLE
chore(miden): pin pm-publisher >=0.1.0a8 (restores the Miden feed)

### DIFF
--- a/pragma-sdk/pyproject.toml
+++ b/pragma-sdk/pyproject.toml
@@ -53,7 +53,7 @@ docs = [
 ]
 
 miden = [
-    "pm-publisher>=0.1.0a7",
+    "pm-publisher>=0.1.0a8",
 ]
 
 dev = [

--- a/pragma-sdk/uv.lock
+++ b/pragma-sdk/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = ">=3.11, <3.13"
 
 [options]
-exclude-newer = "2026-06-27T22:00:00Z"
+exclude-newer = "2026-07-04T22:00:00Z"
 
 [[package]]
 name = "accessible-pygments"
@@ -1252,11 +1252,11 @@ wheels = [
 
 [[package]]
 name = "pm-publisher"
-version = "0.1.0a7"
+version = "0.1.0a8"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b0/c6/80188a6923fe50dc2bd107908bc1f44a9ada1667e9ec45e8b62bc743a1f3/pm_publisher-0.1.0a7-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:d773184ed704e3eed2394856e70b39f309edccaafffb6e9f524e60181650fa36", size = 11275367, upload-time = "2026-06-25T21:04:24.723Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/71/5d58bfe6a6bfc4259dccff5e32e754cac68fdfd98c5b3a0915164c73e13a/pm_publisher-0.1.0a7-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b2e183c97fa321d655bdf55d2b2544738992f539e454e97b9821555f1239755f", size = 12499199, upload-time = "2026-06-25T21:04:26.646Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/9a/0de826110c2c2095bd92612257ce756f349f55686f35a75295b3a99fe1e7/pm_publisher-0.1.0a8-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:e477f89d6cca2d4a1c913fe62ac82a8e1bfeca9e938aaf4c452f157b8b7f1ffc", size = 11275473, upload-time = "2026-07-03T06:47:43.736Z" },
+    { url = "https://files.pythonhosted.org/packages/45/3b/3845bed12b0ae6d6cb564387bdefd253c01eda991a6752407b1f0c2d8413/pm_publisher-0.1.0a8-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:97d024ab24fe474425d9ac1b6c2e5017b81f67b9f295a47551f9a9a9a71bb42e", size = 12497327, upload-time = "2026-07-03T06:47:46.609Z" },
 ]
 
 [[package]]
@@ -1368,7 +1368,7 @@ requires-dist = [
     { name = "moto", extras = ["s3", "secretsmanager"], marker = "extra == 'dev'", specifier = ">=4.2.5" },
     { name = "mypy", marker = "extra == 'typing'", specifier = ">=1.10" },
     { name = "pallets-sphinx-themes", marker = "extra == 'docs'", specifier = ">=2.1.3" },
-    { name = "pm-publisher", marker = "extra == 'miden'", specifier = ">=0.1.0a7" },
+    { name = "pm-publisher", marker = "extra == 'miden'", specifier = ">=0.1.0a8" },
     { name = "poethepoet", marker = "extra == 'dev'", specifier = ">=0.21.1" },
     { name = "pydantic", specifier = ">=2.7.4" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.2.2" },

--- a/price-pusher/uv.lock
+++ b/price-pusher/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = ">=3.11, <3.13"
 
 [options]
-exclude-newer = "2026-06-27T22:00:00Z"
+exclude-newer = "2026-07-04T22:00:00Z"
 
 [[package]]
 name = "aiohappyeyeballs"
@@ -1106,11 +1106,11 @@ wheels = [
 
 [[package]]
 name = "pm-publisher"
-version = "0.1.0a7"
+version = "0.1.0a8"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b0/c6/80188a6923fe50dc2bd107908bc1f44a9ada1667e9ec45e8b62bc743a1f3/pm_publisher-0.1.0a7-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:d773184ed704e3eed2394856e70b39f309edccaafffb6e9f524e60181650fa36", size = 11275367, upload-time = "2026-06-25T21:04:24.723Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/71/5d58bfe6a6bfc4259dccff5e32e754cac68fdfd98c5b3a0915164c73e13a/pm_publisher-0.1.0a7-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b2e183c97fa321d655bdf55d2b2544738992f539e454e97b9821555f1239755f", size = 12499199, upload-time = "2026-06-25T21:04:26.646Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/9a/0de826110c2c2095bd92612257ce756f349f55686f35a75295b3a99fe1e7/pm_publisher-0.1.0a8-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:e477f89d6cca2d4a1c913fe62ac82a8e1bfeca9e938aaf4c452f157b8b7f1ffc", size = 11275473, upload-time = "2026-07-03T06:47:43.736Z" },
+    { url = "https://files.pythonhosted.org/packages/45/3b/3845bed12b0ae6d6cb564387bdefd253c01eda991a6752407b1f0c2d8413/pm_publisher-0.1.0a8-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:97d024ab24fe474425d9ac1b6c2e5017b81f67b9f295a47551f9a9a9a71bb42e", size = 12497327, upload-time = "2026-07-03T06:47:46.609Z" },
 ]
 
 [[package]]
@@ -1195,7 +1195,7 @@ requires-dist = [
     { name = "moto", extras = ["s3", "secretsmanager"], marker = "extra == 'dev'", specifier = ">=4.2.5" },
     { name = "mypy", marker = "extra == 'typing'", specifier = ">=1.10" },
     { name = "pallets-sphinx-themes", marker = "extra == 'docs'", specifier = ">=2.1.3" },
-    { name = "pm-publisher", marker = "extra == 'miden'", specifier = ">=0.1.0a7" },
+    { name = "pm-publisher", marker = "extra == 'miden'", specifier = ">=0.1.0a8" },
     { name = "poethepoet", marker = "extra == 'dev'", specifier = ">=0.21.1" },
     { name = "pydantic", specifier = ">=2.7.4" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.2.2" },


### PR DESCRIPTION
Bumps the `miden` extra to **pm-publisher >=0.1.0a8** and relocks `pragma-sdk` + `price-pusher`.

a8 (pragma-miden #72) fixes the outage: upgrades to **miden-client 0.15.3** and calls `GrpcClient::with_max_decoding_message_size(128 MiB)`, so `sync_state` no longer fails on the node's oversized `SyncTransactions` response (the 4 MiB gRPC decode limit that was blocking publishing). Verified end-to-end on testnet in #72.

The price-pusher image installs pm-publisher via `price-pusher/uv.lock`, so this is what makes a rebuilt image use a8. Relock scoped to pm-publisher only (`--exclude-newer 2026-07-04` overrides the global 7-day setting since a8 was just published).

Next: rebuild the price-pusher image → rollout → feed comes back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)