### PR TITLE
chore(miden): pin pm-publisher >=0.1.0a9 (self-healing wedged store)

### DIFF
--- a/pragma-sdk/pyproject.toml
+++ b/pragma-sdk/pyproject.toml
@@ -53,7 +53,7 @@ docs = [
 ]
 
 miden = [
-    "pm-publisher>=0.1.0a8",
+    "pm-publisher>=0.1.0a9",
 ]
 
 dev = [

--- a/pragma-sdk/uv.lock
+++ b/pragma-sdk/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = ">=3.11, <3.13"
 
 [options]
-exclude-newer = "2026-07-04T22:00:00Z"
+exclude-newer = "2026-08-11T22:00:00Z"
 
 [[package]]
 name = "accessible-pygments"
@@ -1252,11 +1252,11 @@ wheels = [
 
 [[package]]
 name = "pm-publisher"
-version = "0.1.0a8"
+version = "0.1.0a9"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c4/9a/0de826110c2c2095bd92612257ce756f349f55686f35a75295b3a99fe1e7/pm_publisher-0.1.0a8-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:e477f89d6cca2d4a1c913fe62ac82a8e1bfeca9e938aaf4c452f157b8b7f1ffc", size = 11275473, upload-time = "2026-07-03T06:47:43.736Z" },
-    { url = "https://files.pythonhosted.org/packages/45/3b/3845bed12b0ae6d6cb564387bdefd253c01eda991a6752407b1f0c2d8413/pm_publisher-0.1.0a8-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:97d024ab24fe474425d9ac1b6c2e5017b81f67b9f295a47551f9a9a9a71bb42e", size = 12497327, upload-time = "2026-07-03T06:47:46.609Z" },
+    { url = "https://files.pythonhosted.org/packages/39/ca/4309f36c45a0ba8f1d3c1ae56488b38a40d2fecfba132d02610bf3f7304c/pm_publisher-0.1.0a9-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:1acc223396db484a49c344b2e06149144d85dcf72e64a0730d1afdd86f9f3f0d", size = 11280694, upload-time = "2026-08-10T06:19:24.255Z" },
+    { url = "https://files.pythonhosted.org/packages/db/e3/ebdd28a5d7614def9b28f1a200473ccb19a56ac095a5fc4ee5b6f7f31e74/pm_publisher-0.1.0a9-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:acf823059d86f7c218c2411b206f0415121f0bc174522968137291725a4c3450", size = 12514569, upload-time = "2026-08-10T06:19:26.495Z" },
 ]
 
 [[package]]
@@ -1368,7 +1368,7 @@ requires-dist = [
     { name = "moto", extras = ["s3", "secretsmanager"], marker = "extra == 'dev'", specifier = ">=4.2.5" },
     { name = "mypy", marker = "extra == 'typing'", specifier = ">=1.10" },
     { name = "pallets-sphinx-themes", marker = "extra == 'docs'", specifier = ">=2.1.3" },
-    { name = "pm-publisher", marker = "extra == 'miden'", specifier = ">=0.1.0a8" },
+    { name = "pm-publisher", marker = "extra == 'miden'", specifier = ">=0.1.0a9" },
     { name = "poethepoet", marker = "extra == 'dev'", specifier = ">=0.21.1" },
     { name = "pydantic", specifier = ">=2.7.4" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.2.2" },

--- a/price-pusher/uv.lock
+++ b/price-pusher/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = ">=3.11, <3.13"
 
 [options]
-exclude-newer = "2026-07-04T22:00:00Z"
+exclude-newer = "2026-08-11T22:00:00Z"
 
 [[package]]
 name = "aiohappyeyeballs"
@@ -1106,11 +1106,11 @@ wheels = [
 
 [[package]]
 name = "pm-publisher"
-version = "0.1.0a8"
+version = "0.1.0a9"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c4/9a/0de826110c2c2095bd92612257ce756f349f55686f35a75295b3a99fe1e7/pm_publisher-0.1.0a8-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:e477f89d6cca2d4a1c913fe62ac82a8e1bfeca9e938aaf4c452f157b8b7f1ffc", size = 11275473, upload-time = "2026-07-03T06:47:43.736Z" },
-    { url = "https://files.pythonhosted.org/packages/45/3b/3845bed12b0ae6d6cb564387bdefd253c01eda991a6752407b1f0c2d8413/pm_publisher-0.1.0a8-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:97d024ab24fe474425d9ac1b6c2e5017b81f67b9f295a47551f9a9a9a71bb42e", size = 12497327, upload-time = "2026-07-03T06:47:46.609Z" },
+    { url = "https://files.pythonhosted.org/packages/39/ca/4309f36c45a0ba8f1d3c1ae56488b38a40d2fecfba132d02610bf3f7304c/pm_publisher-0.1.0a9-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:1acc223396db484a49c344b2e06149144d85dcf72e64a0730d1afdd86f9f3f0d", size = 11280694, upload-time = "2026-08-10T06:19:24.255Z" },
+    { url = "https://files.pythonhosted.org/packages/db/e3/ebdd28a5d7614def9b28f1a200473ccb19a56ac095a5fc4ee5b6f7f31e74/pm_publisher-0.1.0a9-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:acf823059d86f7c218c2411b206f0415121f0bc174522968137291725a4c3450", size = 12514569, upload-time = "2026-08-10T06:19:26.495Z" },
 ]
 
 [[package]]
@@ -1195,7 +1195,7 @@ requires-dist = [
     { name = "moto", extras = ["s3", "secretsmanager"], marker = "extra == 'dev'", specifier = ">=4.2.5" },
     { name = "mypy", marker = "extra == 'typing'", specifier = ">=1.10" },
     { name = "pallets-sphinx-themes", marker = "extra == 'docs'", specifier = ">=2.1.3" },
-    { name = "pm-publisher", marker = "extra == 'miden'", specifier = ">=0.1.0a8" },
+    { name = "pm-publisher", marker = "extra == 'miden'", specifier = ">=0.1.0a9" },
     { name = "poethepoet", marker = "extra == 'dev'", specifier = ">=0.21.1" },
     { name = "pydantic", specifier = ">=2.7.4" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.2.2" },


### PR DESCRIPTION
Bumps the `miden` extra to **pm-publisher `>=0.1.0a9`** and relocks both uv projects (`pragma-sdk/uv.lock`, `price-pusher/uv.lock`).

## Why

pragma-miden [#74](https://github.com/astraly-labs/pragma-miden/pull/74) (a9) fixes a **silent, permanent Miden outage**: the pyo3 bindings cache the Miden client (and its deadpool SQLite pool) for the whole process lifetime, so the first store panic poisons the pool's Mutex and every later `sync`/`publish_batch` then fails forever with `StoreError(DatabaseError("Panic"))`. The price-pusher just logged + retried each tick while its liveness stayed green off the Starknet feed (observed in prod: 0 restarts in 3d14h, publishing 0/5 the whole time).

a9 detects the wedged-store error and **evicts the cached client**, so the next call rebuilds a fresh one (new pool + Mutex) over the same store file — self-healing within a single tick, no pod restart needed.

## Diff

- `pragma-sdk/pyproject.toml`: `pm-publisher>=0.1.0a8` → `>=0.1.0a9`
- `pragma-sdk/uv.lock` + `price-pusher/uv.lock`: `pm-publisher 0.1.0a8 → 0.1.0a9` (relocked with `uv lock --upgrade-package pm-publisher`, minimal diff)

Smoke-tested: the a9 wheel imports and exposes all 7 bindings (`init`, `publish`, `publish_batch`, `get_entry`, `entry`, `sync`, `import_account`).

## Rollout after merge

Rebuild the price-pusher image (pp-only Cloud Build, tag `v2.13.0a10`, `pullPolicy: Always`) → `kubectl rollout restart deployment/mainnet-price-pusher-service-pragma-sdk -n mainnet`. No devops values change (image tag unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)