### PR TITLE
feat(fetchers): source SURVIVOR/USD from GeckoTerminal (exclude Ekubo)

### DIFF
--- a/pragma-sdk/pragma_sdk/common/fetchers/fetchers/geckoterminal.py
+++ b/pragma-sdk/pragma_sdk/common/fetchers/fetchers/geckoterminal.py
@@ -82,6 +82,10 @@ ASSET_MAPPING: Dict[str, Any] = {
         "starknet-alpha",
         "0x3b405a98c9e795d427fe82cdeeeed803f221b52471e3a757574a2b4180793ee",
     ),
+    "SURVIVOR": (
+        "starknet-alpha",
+        "0x042dd777885ad2c116be96d4d634abc90a26a790ffb5871e037dd5ae7d2ec86b",
+    ),
 }
 
 

--- a/price-pusher/price_pusher/configs/fetchers.py
+++ b/price-pusher/price_pusher/configs/fetchers.py
@@ -14,6 +14,7 @@ from pragma_sdk.common.fetchers.fetchers import (
     KucoinFetcher,
     BybitFetcher,
     EkuboFetcher,
+    GeckoTerminalFetcher,
     BinanceFetcher,
     LbankFetcher,
     BitgetFetcher,
@@ -50,6 +51,7 @@ ALL_SPOT_FETCHERS: List[FetcherInterfaceT] = [
     Re7OnChainFetcher,
     PythFetcher,
     GateioFetcher,
+    GeckoTerminalFetcher,
     # DexscreenerFetcher,
     # CoinbaseFetcher,
     UpbitFetcher,
@@ -82,6 +84,22 @@ CONVERSION_RATE_FETCHERS: FrozenSet[Type[FetcherInterfaceT]] = frozenset(
         WstETHRateLidoFetcher,
     }
 )
+
+# Per-fetcher allowlist: a fetcher listed here ONLY fetches the given pairs
+# (everything else in the config is hidden from it). Used to source a single
+# illiquid asset from one specific source without activating that fetcher for
+# all of its other supported assets.
+FETCHER_RESTRICTED_PAIRS: Dict[Type[FetcherInterfaceT], FrozenSet[str]] = {
+    GeckoTerminalFetcher: frozenset({"SURVIVOR/USD"}),
+}
+
+# Per-fetcher denylist: a fetcher listed here NEVER fetches the given pairs.
+# SURVIVOR/USD is excluded from Ekubo because Ekubo's on-chain PriceFetcher oracle
+# reads a mispriced/stale pool for it (~$0.125 vs ~$0.038 real market, confirmed
+# across every TWAP window), which would poison the published median.
+FETCHER_EXCLUDED_PAIRS: Dict[Type[FetcherInterfaceT], FrozenSet[str]] = {
+    EkuboFetcher: frozenset({"SURVIVOR/USD"}),
+}
 
 ALL_FUTURE_FETCHERS: List[FetcherInterfaceT] = [
     BinanceFutureFetcher,

--- a/price-pusher/price_pusher/core/fetchers.py
+++ b/price-pusher/price_pusher/core/fetchers.py
@@ -16,6 +16,8 @@ from price_pusher.configs.fetchers import (
     ALL_SPOT_FETCHERS,
     CONVERSION_RATE_FETCHERS,
     CONVERSION_RATE_ONLY_PAIRS,
+    FETCHER_RESTRICTED_PAIRS,
+    FETCHER_EXCLUDED_PAIRS,
     FETCHERS_WITH_API_KEY,
 )
 
@@ -93,6 +95,19 @@ async def _add_one_fetcher(
         pairs = {p for p in pairs if str(p) not in CONVERSION_RATE_ONLY_PAIRS}
         if not pairs:
             return
+
+    # Per-fetcher allowlist: restrict this fetcher to specific pairs only.
+    restricted = FETCHER_RESTRICTED_PAIRS.get(fetcher)
+    if restricted is not None:
+        pairs = {p for p in pairs if str(p) in restricted}
+
+    # Per-fetcher denylist: hide specific pairs from this fetcher.
+    excluded = FETCHER_EXCLUDED_PAIRS.get(fetcher)
+    if excluded:
+        pairs = {p for p in pairs if str(p) not in excluded}
+
+    if not pairs:
+        return
 
     init_args = [list(pairs), publisher_name]
     init_kwargs: Dict[str, object] = {}


### PR DESCRIPTION
## Problem

`SURVIVOR/USD` is in `config.mainnet.yaml` but **PRAGMA never publishes it**. In the pod, no active fetcher produces a price, so the orchestrator drops it every tick:
```
WARNING: ORCHESTRATOR tried to flush SURVIVOR/USD:Spot but not found, ignoring...
```
On-chain, the only source was a **third-party publisher (ARGENT)** whose pusher went silent on **2026-08-07** (its last tx succeeded; it pays in STRK and has ample balance — the process is simply down, not out of gas). So the on-chain SURVIVOR/USD feed is frozen on a stale, wrong value.

## Why the price also needs care

SURVIVOR is thinly traded (~$186/24h). Two facts, confirmed on mainnet:
- **Real price ≈ $0.038** — GeckoTerminal API ($0.0375) and CoinGecko's liquid Ekubo pools ($0.0386) agree.
- **Our `EkuboFetcher` returns ~$0.125** (3.3× off). It does *not* read the pool spot; it queries Ekubo's on-chain `PriceFetcher` oracle, which for SURVIVOR is locked onto a mispriced/stale pool that clears the `MIN_TOKENS` liquidity gate — **identical at every TWAP window from 1s to 1h**, so it's structural, not transient. (This is the same path ARGENT used → it published ~$0.129.)

Because the SDK **medians across sources before publishing**, letting Ekubo's $0.125 through would poison the published price (median of $0.125 & $0.0375 ≈ $0.081).

## Change (scoped to SURVIVOR only)

- **`geckoterminal.py`**: add `SURVIVOR` to `ASSET_MAPPING` (Starknet token `0x042dd777…`; validated the GeckoTerminal token endpoint returns `price_usd` matching the market).
- **`configs/fetchers.py`**:
  - add `GeckoTerminalFetcher` to `ALL_SPOT_FETCHERS`;
  - `FETCHER_RESTRICTED_PAIRS` (new allowlist) → GeckoTerminal fetches **only** `SURVIVOR/USD`, so it is *not* activated for its other mapped tokens;
  - `FETCHER_EXCLUDED_PAIRS` (new denylist) → Ekubo **never** fetches `SURVIVOR/USD`.
- **`core/fetchers.py`**: apply both policies in `_add_one_fetcher` (mirrors the existing `CONVERSION_RATE_ONLY_PAIRS` filter).

## Verification

```
GeckoTerminal in ALL_SPOT_FETCHERS: True
Gecko fetches:  ['SURVIVOR/USD']                      # restricted
Ekubo fetches:  ['BTC/USD', 'EKUBO/USD', 'LORDS/USD'] # SURVIVOR excluded
GeckoTerminal SURVIVOR/USD = $0.037555  src=GECKOTERMINAL
```
`ruff check` + `ruff format --check`: clean.

## Notes / follow-ups (deferred on purpose)

- GeckoTerminal is intentionally **not** activated for its other tokens yet ("the rest, later").
- The Ekubo `PriceFetcher` mispricing on illiquid assets is broader than SURVIVOR — worth revisiting how EkuboFetcher sources thin tokens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)