### PR TITLE
feat(assets): add DefiLlama as a 2nd SURVIVOR/USD source

### DIFF
--- a/pragma-sdk/pragma_sdk/supported_assets.yaml
+++ b/pragma-sdk/pragma_sdk/supported_assets.yaml
@@ -400,4 +400,5 @@
 - name: 'Survivor'
   decimals: 18
   ticker: 'SURVIVOR'
+  coingecko_id: 'survivor-2'
   starknet_address: '0x042DD777885AD2C116be96d4D634abC90A26A790ffB5871E037Dd5Ae7d2Ec86B'


### PR DESCRIPTION
Adds `coingecko_id: 'survivor-2'` to SURVIVOR in `supported_assets.yaml` so the already-active **DefiLlama** fetcher sources it, giving SURVIVOR/USD a **second concordant source** alongside GeckoTerminal.

## Verified
- **Same asset**: CoinGecko `survivor-2` → `platforms.starknet` == our token `0x042dd777…`, symbol SURVIVOR.
- **Correct price**: DefiLlama `coingecko:survivor-2` = **$0.0385**, matches GeckoTerminal ($0.0375) and the market.
- **Isolated**: only DefiLlama consumes `coingecko_id`; the GeckoTerminal (address-keyed) and Ekubo-excluded paths are unaffected.

## Why not the others
- **CoinGecko** = the same data as GeckoTerminal (GeckoTerminal is CoinGecko's DEX product) → not independent.
- **Dexscreener**: rejected — its ticker search returns cross-chain homonyms (Solana/BSC "SURVIVOR" tokens) and priced a wrong token at **$0.00011**.

## Caveat (honest)
DefiLlama's price is CoinGecko-derived, so it's **correlated** with GeckoTerminal — real benefit is redundancy against a GeckoTerminal endpoint outage, not independent price discovery. SURVIVOR trades on a single thin market (~$40/24h Ekubo pools), so true source diversity isn't achievable for this asset; the main robustness comes from the oracle's staleness filtering + multiple publishers.

## Rollout (after merge)
Bump `2.13.0 → 2.13.1` + cut GitHub Release `v2.13.1` (public image for external publishers) + rebuild our private prod image and rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)